### PR TITLE
[KEH-694 + 696] - Allow expansion of data point detail dialog

### DIFF
--- a/frontend/src/components/InfoBox/InfoBox.js
+++ b/frontend/src/components/InfoBox/InfoBox.js
@@ -27,6 +27,8 @@ const InfoBox = ({
   const [isDragging, setIsDragging] = useState(false);
   const [dragPosition, setDragPosition] = useState(initialPosition);
   const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
+  const [localTitle, setLocalTitle] = useState(selectedItem?.title || "");
+  const [localCategory, setLocalCategory] = useState(selectedItem?.description || "");
 
   const handleMouseDown = (e) => {
     e.stopPropagation(); // Prevent event from bubbling to parent
@@ -66,6 +68,13 @@ const InfoBox = ({
       document.removeEventListener("mouseup", handleMouseUp);
     };
   }, [isDragging, dragOffset]);
+
+  useEffect(() => {
+    if (selectedItem) {
+      setLocalTitle(selectedItem.title);
+      setLocalCategory(selectedItem.description);
+    }
+  }, [selectedItem]);
 
   const handleEditClick = () => {
     setEditedTitle(selectedItem.title);
@@ -173,7 +182,7 @@ const InfoBox = ({
           </>
         ) : (
           <>
-            <h3>{selectedItem.title}</h3>
+            <h3>{localTitle}</h3>
             {isAdmin && (
               <button className="edit-button" onClick={handleEditClick}>
                 <FaEdit size={12} />
@@ -183,7 +192,7 @@ const InfoBox = ({
         )}
       </div>
       <div className="info-box-header">
-        <p className="info-box-ring">{selectedItem.description}</p>
+        <p className="info-box-ring">{localCategory}</p>
         <span
           className={`info-box-ring ${selectedItem.timeline[
             selectedItem.timeline.length - 1

--- a/frontend/src/components/InfoBox/InfoBox.js
+++ b/frontend/src/components/InfoBox/InfoBox.js
@@ -1,0 +1,291 @@
+import React, { useState, useEffect } from "react";
+import {
+  IoArrowUpOutline,
+  IoArrowDownOutline,
+  IoRemoveOutline,
+  IoGridOutline,
+} from "react-icons/io5";
+import { FaSortAmountDownAlt, FaSortAmountUpAlt, FaEdit, FaCheck, FaTimes } from "react-icons/fa";
+
+const InfoBox = ({
+  isAdmin = false,
+  selectedItem,
+  initialPosition = { x: 24, y: 80 },
+  onClose,
+  timelineAscending,
+  setTimelineAscending,
+  selectedTimelineItem,
+  setSelectedTimelineItem,
+  projectsForTech,
+  handleProjectClick,
+  onEditConfirm,
+  onEditCancel,
+}) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editedTitle, setEditedTitle] = useState("");
+  const [editedCategory, setEditedCategory] = useState("");
+  const [isDragging, setIsDragging] = useState(false);
+  const [dragPosition, setDragPosition] = useState(initialPosition);
+  const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
+
+  const handleMouseDown = (e) => {
+    e.stopPropagation(); // Prevent event from bubbling to parent
+    setIsDragging(true);
+    const infoBox = e.currentTarget.closest('.info-box');
+    const infoBoxRect = infoBox.getBoundingClientRect();
+    const clickX = e.clientX - infoBoxRect.left;
+    const clickY = e.clientY - infoBoxRect.top;
+    
+    setDragOffset({
+      x: clickX,
+      y: clickY,
+    });
+  };
+
+  useEffect(() => {
+    const handleMouseMove = (e) => {
+      if (isDragging) {
+        setDragPosition({
+          x: e.clientX - dragOffset.x,
+          y: e.clientY - dragOffset.y,
+        });
+      }
+    };
+
+    const handleMouseUp = () => {
+      setIsDragging(false);
+    };
+
+    if (isDragging) {
+      document.addEventListener("mousemove", handleMouseMove);
+      document.addEventListener("mouseup", handleMouseUp);
+    }
+
+    return () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [isDragging, dragOffset]);
+
+  const handleEditClick = () => {
+    setEditedTitle(selectedItem.title);
+    setEditedCategory(selectedItem.description);
+    setIsEditing(true);
+  };
+
+  const handleCancelEdit = () => {
+    setIsEditing(false);
+    setEditedTitle("");
+    setEditedCategory("");
+    if (onEditCancel) onEditCancel();
+  };
+
+  const handleConfirmEdit = () => {
+    if (onEditConfirm) {
+      onEditConfirm(editedTitle, editedCategory);
+    }
+    setIsEditing(false);
+  };
+
+  if (!selectedItem) {
+    return (
+      <div
+        className="info-box"
+        style={{
+          position: "fixed",
+          left: dragPosition.x,
+          top: dragPosition.y,
+          transform: "none",
+          boxShadow: isDragging
+            ? "0 4px 10px 0 hsl(var(--foreground) / 0.1)"
+            : "none",
+          minHeight: "100px",
+          justifyContent: "center",
+          resize: "none",
+          cursor: "grab",
+        }}
+        onMouseDown={handleMouseDown}
+      >
+        <button className="info-box-close" onClick={onClose}>
+          ×
+        </button>
+        <p className="info-box-placeholder">
+          Hover over a blip to see details or click to lock the selection
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="info-box"
+      style={{
+        position: "fixed",
+        left: dragPosition.x,
+        top: dragPosition.y,
+        transform: "none",
+        boxShadow: isDragging
+          ? "0 4px 10px 0 hsl(var(--foreground) / 0.1)"
+          : "none",
+        resize: "both",
+        overflow: "auto",
+        maxWidth: "90vw",
+        maxHeight: "450px",
+      }}
+    >
+      <button className="info-box-close" onClick={onClose}>
+        ×
+      </button>
+      <div className="info-box-header">
+        <div className="info-box-drag-handle" onMouseDown={handleMouseDown}>
+          <IoGridOutline size={12} />
+        </div>
+        {selectedItem.number && (
+             <span className="info-box-number">#{selectedItem.number}</span>
+        )}
+       
+        {isEditing ? (
+          <>
+            <input
+              type="text"
+              value={editedTitle}
+              onChange={(e) => setEditedTitle(e.target.value)}
+              className="edit-title-input"
+            />
+            <select
+              value={editedCategory}
+              onChange={(e) => setEditedCategory(e.target.value)}
+              className="edit-category-select"
+            >
+              <option value="Languages">Languages</option>
+              <option value="Frameworks">Frameworks</option>
+              <option value="Supporting Tools">Supporting Tools</option>
+              <option value="Infrastructure">Infrastructure</option>
+            </select>
+            <div className="edit-buttons">
+              <button className="edit-confirm-button" onClick={handleConfirmEdit}>
+                <FaCheck size={12} />
+              </button>
+              <button className="edit-cancel-button" onClick={handleCancelEdit}>
+                <FaTimes size={12} />
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <h3>{selectedItem.title}</h3>
+            {isAdmin && (
+              <button className="edit-button" onClick={handleEditClick}>
+                <FaEdit size={12} />
+              </button>
+            )}
+          </>
+        )}
+      </div>
+      <div className="info-box-header">
+        <p className="info-box-ring">{selectedItem.description}</p>
+        <span
+          className={`info-box-ring ${selectedItem.timeline[
+            selectedItem.timeline.length - 1
+          ].ringId.toLowerCase()}`}
+        >
+          {selectedItem.timeline[selectedItem.timeline.length - 1].ringId}
+        </span>
+      </div>
+
+      <div className="timeline-header">
+        <div className="timeline-header-title">
+          <h4>Timeline</h4>
+          <button
+            className="timeline-sort-button"
+            onClick={() => setTimelineAscending(!timelineAscending)}
+            title={timelineAscending ? "Newest first" : "Oldest first"}
+          >
+            {timelineAscending ? (
+              <FaSortAmountDownAlt size={12} />
+            ) : (
+              <FaSortAmountUpAlt size={12} />
+            )}
+          </button>
+        </div>
+        <p>Click a box to show the description of the event</p>
+      </div>
+
+      <div className="timeline-container">
+        {[...selectedItem.timeline]
+          .reverse()
+          .slice()
+          [timelineAscending ? "reverse" : "slice"]()
+          .map((timelineItem, index, array) => (
+            <div
+              key={timelineItem.date + timelineItem.ringId + index}
+              className="timeline-item"
+            >
+              <div
+                className={`timeline-node ${timelineItem.ringId.toLowerCase()}`}
+                onClick={() =>
+                  setSelectedTimelineItem(
+                    timelineItem === selectedTimelineItem ? null : timelineItem
+                  )
+                }
+              >
+                <span className="timeline-movement">
+                  {timelineItem.moved > 0 && <IoArrowUpOutline size={10} />}
+                  {timelineItem.moved === 0 && <IoRemoveOutline size={10} />}
+                  {timelineItem.moved < 0 && <IoArrowDownOutline size={10} />}
+                </span>
+                {selectedTimelineItem === timelineItem
+                  ? timelineItem.description
+                  : new Date(timelineItem.date).toLocaleDateString("en-GB", {
+                      month: "short",
+                      year: "numeric",
+                    })}
+              </div>
+              {index < array.length - 1 && <div className="timeline-connector" />}
+            </div>
+          ))}
+      </div>
+
+      {projectsForTech.length > 0 && (
+        <div className="info-box-projects">
+          <h4>
+            <strong>
+              {projectsForTech.length}{" "}
+              {projectsForTech.length === 1 ? "project" : "projects"}
+            </strong>{" "}
+            using this technology:
+          </h4>
+          <p>Click a project to view more details</p>
+          <ul>
+            {projectsForTech.map((project, index) => (
+              <li
+                key={index}
+                onClick={() => handleProjectClick(project)}
+                className="info-box-project-item clickable-tech"
+              >
+                {project.Project || project.Project_Short}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {selectedItem.links && selectedItem.links.length > 0 && (
+        <ul className="info-box-links">
+          {selectedItem.links.map((link, index) => (
+            <a
+              key={index}
+              href={link}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {link}
+            </a>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default InfoBox;

--- a/frontend/src/pages/RadarPage.js
+++ b/frontend/src/pages/RadarPage.js
@@ -17,6 +17,7 @@ import { FaSortAmountDownAlt, FaSortAmountUpAlt } from "react-icons/fa";
 import { fetchCSVFromS3 } from "../utilities/getCSVData";
 import { fetchTechRadarJSONFromS3 } from "../utilities/getTechRadarJson";
 import ProjectModal from "../components/Projects/ProjectModal";
+import InfoBox from "../components/InfoBox/InfoBox";
 
 /**
  * RadarPage component for displaying the radar page.
@@ -604,167 +605,18 @@ function RadarPage() {
       />
       <div className="radar-page">
         {isInfoBoxVisible && (
-          <div
-            className="info-box"
-            style={{
-              position: "fixed",
-              left: dragPosition.x,
-              top: dragPosition.y,
-              transform: "none",
-              cursor: isDragging ? "grabbing" : "grab",
-              boxShadow: isDragging
-                ? "0 4px 10px 0 hsl(var(--foreground) / 0.1)"
-                : "none",
-            }}
-            onMouseDown={handleMouseDown}
-          >
-            <button
-              className="info-box-close"
-              onClick={() => setIsInfoBoxVisible(false)}
-            >
-              ×
-            </button>
-            {selectedBlip || lockedBlip ? (
-              <>
-                <div className="info-box-header">
-                  <span className="info-box-number">
-                    #{(selectedBlip || lockedBlip).number}
-                  </span>
-                  <h3>{(selectedBlip || lockedBlip).title}</h3>
-                </div>
-                <div className="info-box-header">
-                  <p className="info-box-ring">
-                    {(selectedBlip || lockedBlip).description}
-                  </p>
-                  <span
-                    className={`info-box-ring ${(
-                      selectedBlip || lockedBlip
-                    ).timeline[
-                      selectedBlip.timeline.length - 1
-                    ].ringId.toLowerCase()}`}
-                  >
-                    {
-                      (selectedBlip || lockedBlip).timeline[
-                        selectedBlip.timeline.length - 1
-                      ].ringId
-                    }
-                  </span>
-                </div>
-
-                <div className="timeline-header">
-                  <div className="timeline-header-title">
-                    <h4>Timeline</h4>
-                    <button
-                      className="timeline-sort-button"
-                      onClick={() => setTimelineAscending(!timelineAscending)}
-                      title={
-                        timelineAscending ? "Newest first" : "Oldest first"
-                      }
-                    >
-                      {timelineAscending ? (
-                        <FaSortAmountDownAlt size={12} />
-                      ) : (
-                        <FaSortAmountUpAlt size={12} />
-                      )}
-                    </button>
-                  </div>
-                  <p>Click a box to show the description of the event</p>
-                </div>
-
-                <div className="timeline-container">
-                  {[...(selectedBlip || lockedBlip).timeline]
-                    .reverse()
-                    .slice()
-                    [timelineAscending ? "reverse" : "slice"]()
-                    .map((timelineItem, index, array) => (
-                      <div
-                        key={timelineItem.date + timelineItem.ringId + index}
-                        className="timeline-item"
-                      >
-                        <div
-                          className={`timeline-node ${timelineItem.ringId.toLowerCase()}`}
-                          onClick={() =>
-                            setSelectedTimelineItem(
-                              timelineItem === selectedTimelineItem
-                                ? null
-                                : timelineItem
-                            )
-                          }
-                        >
-                          <span className="timeline-movement">
-                            {timelineItem.moved > 0 && (
-                              <IoArrowUpOutline size={10} />
-                            )}
-                            {timelineItem.moved === 0 && (
-                              <IoRemoveOutline size={10} />
-                            )}
-                            {timelineItem.moved < 0 && (
-                              <IoArrowDownOutline size={10} />
-                            )}
-                          </span>
-                          {selectedTimelineItem === timelineItem
-                            ? timelineItem.description
-                            : new Date(timelineItem.date).toLocaleDateString(
-                                "en-GB",
-                                {
-                                  month: "short",
-                                  year: "numeric",
-                                }
-                              )}
-                        </div>
-                        {index < array.length - 1 && (
-                          <div className="timeline-connector" />
-                        )}
-                      </div>
-                    ))}
-                </div>
-
-                {projectsForTech.length > 0 && (
-                  <div className="info-box-projects">
-                    <h4>
-                      <strong>
-                        {projectsForTech.length}{" "}
-                        {projectsForTech.length === 1 ? "project" : "projects"}
-                      </strong>{" "}
-                      using this technology:
-                    </h4>
-                    <p>Click a project to view more details</p>
-                    <ul>
-                      {projectsForTech.map((project, index) => (
-                        <li
-                          key={index}
-                          onClick={() => handleProjectClick(project)}
-                          className="info-box-project-item clickable-tech"
-                        >
-                          {project.Project || project.Project_Short}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-
-                {(selectedBlip || lockedBlip).links &&
-                  (selectedBlip || lockedBlip).links.length > 0 && (
-                    <ul className="info-box-links">
-                      {(selectedBlip || lockedBlip).links.map((link, index) => (
-                        <a
-                          key={index}
-                          href={link}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          {link}
-                        </a>
-                      ))}
-                    </ul>
-                  )}
-              </>
-            ) : (
-              <p className="info-box-placeholder">
-                Hover over a blip to see details or click to lock the selection
-              </p>
-            )}
-          </div>
+          <InfoBox
+            isAdmin={false}
+            selectedItem={selectedBlip || lockedBlip}
+            initialPosition={{ x: 24, y: 80 }}
+            onClose={() => setIsInfoBoxVisible(false)}
+            timelineAscending={timelineAscending}
+            setTimelineAscending={setTimelineAscending}
+            selectedTimelineItem={selectedTimelineItem}
+            setSelectedTimelineItem={setSelectedTimelineItem}
+            projectsForTech={projectsForTech}
+            handleProjectClick={handleProjectClick}
+          />
         )}
 
         <div className="quadrant-lists">

--- a/frontend/src/pages/ReviewPage.js
+++ b/frontend/src/pages/ReviewPage.js
@@ -14,7 +14,12 @@ import {
 } from "react-icons/fa";
 import SkeletonStatCard from "../components/Statistics/Skeletons/SkeletonStatCard";
 import MultiSelect from "../components/MultiSelect/MultiSelect";
-import { IoArrowUpOutline, IoArrowDownOutline, IoRemoveOutline } from "react-icons/io5";
+import {
+  IoArrowUpOutline,
+  IoArrowDownOutline,
+  IoRemoveOutline,
+} from "react-icons/io5";
+import InfoBox from "../components/InfoBox/InfoBox";
 
 const ReviewPage = () => {
   const [entries, setEntries] = useState({
@@ -46,6 +51,9 @@ const ReviewPage = () => {
   const [showMoveModal, setShowMoveModal] = useState(false);
   const [pendingMove, setPendingMove] = useState(null);
   const [moveDescription, setMoveDescription] = useState("");
+  const [isDragging, setIsDragging] = useState(false);
+  const [dragPosition, setDragPosition] = useState({ x: 24, y: 80 });
+  const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
 
   // Fields to scan from CSV and their corresponding categories
   const fieldsToScan = {
@@ -182,14 +190,12 @@ const ReviewPage = () => {
     const destIndex = ringOrder.indexOf(destRing.toLowerCase());
 
     // If either ring is 'review', 'ignore' or rings are the same, no movement
-    if (
-      sourceRing === destRing
-    ) {
+    if (sourceRing === destRing) {
       return 0;
     }
 
     // Calculate movement based on index difference
-    console.log(destIndex, sourceIndex, destIndex - sourceIndex)
+    console.log(destIndex, sourceIndex, destIndex - sourceIndex);
     return destIndex - sourceIndex;
   };
 
@@ -481,114 +487,65 @@ const ReviewPage = () => {
     setShowAddConfirmModal(false);
   };
 
-  const renderTimeline = () => {
-    if (!selectedItem) {
-      return (
-        <div className="timeline-display">
-          <div className="timeline-empty">
-            Click on an item to view its timeline and edit the details
-          </div>
-        </div>
-      );
+  // Add mouse handlers
+  const handleMouseDown = (e) => {
+    setIsDragging(true);
+    const rect = e.currentTarget.getBoundingClientRect();
+    setDragOffset({
+      x: e.clientX - rect.left,
+      y: e.clientY - rect.top,
+    });
+  };
+
+  useEffect(() => {
+    const handleMouseMove = (e) => {
+      if (isDragging) {
+        setDragPosition({
+          x: e.clientX - dragOffset.x,
+          y: e.clientY - dragOffset.y,
+        });
+      }
+    };
+
+    const handleMouseUp = () => {
+      setIsDragging(false);
+    };
+
+    if (isDragging) {
+      document.addEventListener("mousemove", handleMouseMove);
+      document.addEventListener("mouseup", handleMouseUp);
     }
 
-    const timelineEntries = timelineAscending
-      ? [...selectedItem.timeline]
-      : [...selectedItem.timeline].reverse();
+    return () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [isDragging, dragOffset]);
+
+  const renderTimeline = () => {
+    if (!selectedItem) {
+      return null;
+    }
 
     return (
-      <div className="timeline-display">
-        <div className="timeline-display-header">
-          {isEditing ? (
-            <>
-              <input
-                type="text"
-                value={editedTitle}
-                onChange={(e) => setEditedTitle(e.target.value)}
-                className="edit-title-input"
-              />
-              <select
-                value={editedCategory}
-                onChange={(e) => setEditedCategory(e.target.value)}
-                className="edit-category-select"
-              >
-                <option value="Languages">Languages</option>
-                <option value="Frameworks">Frameworks</option>
-                <option value="Supporting Tools">Supporting Tools</option>
-                <option value="Infrastructure">Infrastructure</option>
-              </select>
-              <div className="edit-buttons">
-                <button
-                  className="edit-confirm-button"
-                  onClick={handleConfirmEdit}
-                >
-                  <FaCheck size={12} />
-                </button>
-                <button
-                  className="edit-cancel-button"
-                  onClick={handleCancelEdit}
-                >
-                  <FaTimes size={12} />
-                </button>
-              </div>
-            </>
-          ) : (
-            <>
-              <h3>{selectedItem.title}</h3>
-              <p>{selectedItem.description}</p>
-              <button className="edit-button" onClick={handleEditClick}>
-                <FaEdit size={12} />
-              </button>
-            </>
-          )}
-          <button
-            className="timeline-sort-button"
-            onClick={() => setTimelineAscending(!timelineAscending)}
-            title={timelineAscending ? "Original order" : "Reverse order"}
-          >
-            {timelineAscending ? (
-              <FaSortAmountDownAlt size={12} />
-            ) : (
-              <FaSortAmountUpAlt size={12} />
-            )}
-          </button>
-        </div>
-        <div className="timeline-info">
-          Click a box to show more info about the event
-        </div>
-        <div className="timeline-entries">
-          {timelineEntries.map((entry, index, array) => (
-            <div
-              key={entry.date + entry.ringId + index}
-              className="timeline-item"
-            >
-              <div
-                className={`timeline-node ${entry.ringId.toLowerCase()}`}
-                onClick={() =>
-                  setExpandedTimelineEntry(
-                    expandedTimelineEntry === index ? null : index
-                  )
-                }
-              >
-                <span className="timeline-movement">
-                  {entry.moved > 0 && <IoArrowUpOutline size={10} />}
-                  {entry.moved === 0 && <IoRemoveOutline size={10} />}
-                  {entry.moved < 0 && <IoArrowDownOutline size={10} />}
-                </span>
-                {expandedTimelineEntry === index
-                  ? entry.description
-                  : new Date(entry.date).toLocaleDateString("en-GB", {
-                      month: "short",
-                      year: "numeric",
-                    })}
-              </div>
-              {index < array.length - 1 && (
-                <div className="timeline-connector" />
-              )}
-            </div>
-          ))}
-        </div>
-      </div>
+      <InfoBox
+        isAdmin={true}
+        selectedItem={selectedItem}
+        initialPosition={{ x: 24, y: 80 }}
+        onClose={() => setSelectedItem(null)}
+        timelineAscending={timelineAscending}
+        setTimelineAscending={setTimelineAscending}
+        selectedTimelineItem={expandedTimelineEntry}
+        setSelectedTimelineItem={setExpandedTimelineEntry}
+        projectsForTech={[]}
+        handleProjectClick={() => {}}
+        onEditConfirm={(title, category) => {
+          setEditedTitle(title);
+          setEditedCategory(category);
+          handleConfirmEdit();
+        }}
+        onEditCancel={handleCancelEdit}
+      />
     );
   };
 
@@ -722,7 +679,7 @@ const ReviewPage = () => {
           </div>
           <div className="admin-search-filter">
             {isLoading ? (
-                <SkeletonStatCard minWidth="400px"/>
+              <SkeletonStatCard minWidth="400px" />
             ) : (
               renderTimeline()
             )}

--- a/frontend/src/pages/ReviewPage.js
+++ b/frontend/src/pages/ReviewPage.js
@@ -5,20 +5,8 @@ import Header from "../components/Header/Header";
 import { ThemeProvider } from "../contexts/ThemeContext";
 import "../styles/ReviewPage.css";
 import { toast } from "react-hot-toast";
-import {
-  FaSortAmountDownAlt,
-  FaSortAmountUpAlt,
-  FaEdit,
-  FaCheck,
-  FaTimes,
-} from "react-icons/fa";
 import SkeletonStatCard from "../components/Statistics/Skeletons/SkeletonStatCard";
 import MultiSelect from "../components/MultiSelect/MultiSelect";
-import {
-  IoArrowUpOutline,
-  IoArrowDownOutline,
-  IoRemoveOutline,
-} from "react-icons/io5";
 import InfoBox from "../components/InfoBox/InfoBox";
 
 const ReviewPage = () => {
@@ -355,10 +343,6 @@ const ReviewPage = () => {
     setSelectedItem(selectedItem?.id === item.id ? null : item);
   };
 
-  const handleTimelineEntryClick = (index) => {
-    setExpandedTimelineEntry(expandedTimelineEntry === index ? null : index);
-  };
-
   const handleAddClick = () => {
     if (!newTechnology.trim()) {
       toast.error("Please enter a technology name");
@@ -419,8 +403,6 @@ const ReviewPage = () => {
       ...selectedItem,
       title: editedTitle,
       description: editedCategory,
-      id: `${editedTitle.toLowerCase().replace(/\s+/g, "")}-${Date.now()}`,
-      key: `${editedTitle.toLowerCase().replace(/\s+/g, "")}-${Date.now()}`,
       quadrant: categoryToQuadrant[editedCategory],
     });
   };
@@ -434,7 +416,7 @@ const ReviewPage = () => {
 
   const handleConfirmModalYes = () => {
     const currentRing =
-      selectedItem.timeline[selectedItem.timeline.length - 1].ringId;
+      selectedItem.timeline[selectedItem.timeline.length - 1].ringId.toLowerCase();
 
     // Create timeline entry for the change
     const now = new Date().toISOString().split("T")[0];
@@ -447,7 +429,10 @@ const ReviewPage = () => {
 
     // Update the item with new values and timeline
     const updatedItem = {
-      ...editedItem,
+      ...selectedItem,
+      title: editedTitle,
+      description: editedCategory,
+      quadrant: categoryToQuadrant[editedCategory],
       timeline: [...selectedItem.timeline, timelineEntry],
     };
 

--- a/frontend/src/styles/App.css
+++ b/frontend/src/styles/App.css
@@ -442,13 +442,86 @@ text {
   min-height: 64px;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 8px;
   text-align: left;
-  user-select: none; /* Prevent text selection while dragging */
+  user-select: none;
+  resize: both;
+  overflow: auto;
+  max-width: 800px;
+  min-width: 400px;
+  max-height: 80vh;
+  min-height: 160px;
 }
-.info-box:active::before {
+
+.info-box-drag-handle {
+  padding: 4px;
+  cursor: grab;
+  color: hsl(var(--muted-foreground));
+  opacity: 0.6;
+  transition: all 0.2s ease;
+  border-radius: var(--radius);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2;
+}
+
+.info-box-drag-handle:hover {
+  opacity: 1;
+  background: hsl(var(--muted));
+}
+
+.info-box-drag-handle:active {
   cursor: grabbing;
+  opacity: 1;
+  background: hsl(var(--muted));
+}
+
+/* Update resize handle styling */
+.info-box::-webkit-resizer {
+  border-radius: 0 0 var(--radius) 0;
+  background: hsl(var(--muted));
+  border: 1px solid hsl(var(--border));
+  cursor: se-resize;
+}
+
+/* Add padding to account for drag handle */
+.info-box-header {
+  padding-left: 0px;
+}
+
+/* Update close button position */
+.info-box-close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: none;
+  border: none;
+  font-size: 20px;
+  color: hsl(var(--muted-foreground));
+  cursor: pointer;
+  padding: 5px;
+  line-height: 1;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+  z-index: 2;
+}
+
+.info-box-close:hover {
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+}
+
+/* Ensure content area is scrollable */
+.info-box-content {
+  overflow: auto;
+  flex: 1;
 }
 
 .info-box h3 {
@@ -594,10 +667,6 @@ foreignObject {
 .blip-highlight {
   transition: all 0.2s ease;
   pointer-events: none;
-}
-
-.blip-container {
-  cursor: pointer;
 }
 
 .blip-container:hover .blip {

--- a/frontend/src/styles/ReviewPage.css
+++ b/frontend/src/styles/ReviewPage.css
@@ -213,6 +213,12 @@
   }
 }
 
+@media (max-width: 580px) {
+  .admin-grid {
+    grid-template-columns: repeat(1, 1fr);
+  }
+}
+
 .admin-box {
   background: hsl(var(--card));
   border-radius: var(--radius);
@@ -311,6 +317,12 @@
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 8px;
+}
+
+@media (max-width: 420px) {
+  .droppable-group-items {
+    grid-template-columns: repeat(1, 1fr);
+  }
 }
 
 .droppable-area {
@@ -749,16 +761,14 @@ textarea.technology-input {
 }
 
 .destructive {
-  border-bottom: 1px solid hsl(var(--destructive)) !important;
-  border-radius: var(--radius);
+  background-color: hsl(var(--destructive) / .4);
   padding: 2px 8px;
   box-sizing: border-box;
   width: fit-content;
 }
 
 .constructive {
-  border-bottom: 1px solid green !important;
-  border-radius: var(--radius);
+  background-color: hsl(120 100% 25% / .4);
   padding: 2px 8px;
   box-sizing: border-box;
   width: fit-content;


### PR DESCRIPTION
Moved the info-box into it's own component as it's now being used by the Radar and Review pages.
Added the resize functionality to the box.
`isAdmin` allows the Review page to edit the details.
Review page uses the info-box instead of it's own `timeline-display`.