### PR TITLE
iam.tf naming error

### DIFF
--- a/terraform/service/iam.tf
+++ b/terraform/service/iam.tf
@@ -56,8 +56,8 @@ resource "aws_iam_role_policy" "s3_read_only" {
         Resource = [
           "arn:aws:s3:::${var.s3_bucket_name}",
           "arn:aws:s3:::${var.s3_bucket_name}/*",
-          "arn:aws:s3:::${var.other_s3_bucket_name}",
-          "arn:aws:s3:::${var.other_s3_bucket_name}/*"
+          "arn:aws:s3:::${var.api_s3_bucket_name}",
+          "arn:aws:s3:::${var.api_s3_bucket_name}/*"
         ]
       }
     ]


### PR DESCRIPTION
```diff
        Resource = [
          "arn:aws:s3:::${var.s3_bucket_name}",
          "arn:aws:s3:::${var.s3_bucket_name}/*",
+          "arn:aws:s3:::${var.api_s3_bucket_name}",
+          "arn:aws:s3:::${var.api_s3_bucket_name}/*"
```