### PR TITLE
[KEH-698] - Move S3 Terraform from old repo to Digital Landscape repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,22 @@ terraform plan -var-file=env/dev/dev.tfvars
 terraform apply -var-file=env/dev/dev.tfvars
 ```
 
+Change directory to the storage folder (if in service folder):
+
+```bash
+cd ../storage
+```
+
+Set the environment variables. Check the `terraform/storage/env/dev/example_tfvars.txt` file for the correct values.
+
+Run Terraform:
+
+```bash
+terraform init -backend-config="env/dev/backend-dev" -reconfigure
+terraform plan -var-file=env/dev/dev.tfvars
+terraform apply -var-file=env/dev/dev.tfvars
+```
+
 ### Makefile
 
 To see the available commands, run the following command:

--- a/terraform/storage/env/dev/backend-dev.tfbackend
+++ b/terraform/storage/env/dev/backend-dev.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "sdp-dev-tf-state"
+key            = "sdp-dev-tech-radar-storage/terraform.tfstate"
+region         = "eu-west-2"
+dynamodb_table = "terraform-state-lock"

--- a/terraform/storage/env/dev/example_tfvars.txt
+++ b/terraform/storage/env/dev/example_tfvars.txt
@@ -1,0 +1,5 @@
+aws_account_id        = "<your_account_id>"
+aws_access_key_id     = "<your_access_key_id>"
+aws_secret_access_key = "<your_secret_access_key>"
+domain                = "sdp-dev"
+service_subdomain     = "tech-radar"

--- a/terraform/storage/env/prod/backend-prod.tfbackend
+++ b/terraform/storage/env/prod/backend-prod.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "sdp-prod-tf-state"
+key            = "sdp-prod-digital-landscape-storage/terraform.tfstate"
+region         = "eu-west-2"
+dynamodb_table = "sdp-prod-terraform-state-lock"

--- a/terraform/storage/main.tf
+++ b/terraform/storage/main.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    # Backend is selected using terraform init -backend-config=path/to/backend-<env>.tfbackend
+    # bucket         = "sdp-dev-tf-state"
+    # key            = "sdp-dev-tech-radar-storage/terraform.tfstate"
+    # region         = "eu-west-2"
+    # dynamodb_table = "terraform-state-lock"
+  }
+}

--- a/terraform/storage/outputs.tf
+++ b/terraform/storage/outputs.tf
@@ -1,0 +1,6 @@
+output "data_bucket_name" {
+  value = aws_s3_bucket.data_bucket.bucket
+}
+output "data_bucket_id" {
+  value = aws_s3_bucket.data_bucket.id
+}

--- a/terraform/storage/providers.tf
+++ b/terraform/storage/providers.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+  default_tags {
+    tags = {
+      "Project"       = var.project_tag
+      "TeamOwner"     = var.team_owner_tag
+      "BusinessOwner" = var.business_owner_tag
+      "Service"       = var.service_subdomain
+      "Environment"   = var.domain
+      "Terraform"     = "true"
+    }
+  }
+
+}

--- a/terraform/storage/storage.tf
+++ b/terraform/storage/storage.tf
@@ -1,0 +1,49 @@
+resource "aws_s3_bucket" "data_bucket" {
+  bucket = "${var.domain}-${var.service_subdomain}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_versioning" "enabled" {
+  bucket = aws_s3_bucket.data_bucket.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "blocked" {
+  bucket = aws_s3_bucket.data_bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "encrypt_by_default" {
+  bucket = aws_s3_bucket.data_bucket.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_cors_configuration" "cors_config" {
+  bucket = aws_s3_bucket.data_bucket.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET", "PUT", "POST"]
+    allowed_origins = [
+      "https://tech-radar.sdp-dev.aws.onsdigital.uk/*",
+      "https://digital-landscape.sdp-prod.aws.onsdigital.uk/*"
+    ]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3000
+  }
+}

--- a/terraform/storage/variables.tf
+++ b/terraform/storage/variables.tf
@@ -1,0 +1,50 @@
+variable "aws_account_id" {
+  description = "AWS Account ID"
+  type        = string
+}
+
+variable "aws_access_key_id" {
+  description = "AWS Access Key ID"
+  type        = string
+}
+
+variable "aws_secret_access_key" {
+  description = "AWS Secret Access Key"
+  type        = string
+}
+
+variable "service_subdomain" {
+  description = "Service subdomain"
+  type        = string
+  default     = "tech-radar"
+}
+
+variable "domain" {
+  description = "Domain name (e.g., sdp-dev)"
+  type        = string
+  default     = "sdp-dev"
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "eu-west-2"
+}
+
+variable "project_tag" {
+  description = "Project"
+  type        = string
+  default     = "TRT"
+}
+
+variable "team_owner_tag" {
+  description = "Team Owner"
+  type        = string
+  default     = "Knowledge Exchange Hub"
+}
+
+variable "business_owner_tag" {
+  description = "Business Owner"
+  type        = string
+  default     = "DST"
+}


### PR DESCRIPTION
Moved the TF from [here](https://github.com/ONS-Innovation/keh-tech-radar-lambda/tree/main/terraform/storage) and updated it as it was needed.

Also I manually (on GUI) deployed the prod version of the bucket so I removed that then redeployed it with Terraform. Everything works on prod so no disruption.