### PR TITLE
small fixes

### DIFF
--- a/frontend/src/pages/RadarPage.js
+++ b/frontend/src/pages/RadarPage.js
@@ -9,11 +9,7 @@ import {
   IoGridOutline,
   IoChevronUpOutline,
   IoChevronDownOutline,
-  IoArrowUpOutline,
-  IoArrowDownOutline,
-  IoRemoveOutline,
 } from "react-icons/io5";
-import { FaSortAmountDownAlt, FaSortAmountUpAlt } from "react-icons/fa";
 import { fetchCSVFromS3 } from "../utilities/getCSVData";
 import { fetchTechRadarJSONFromS3 } from "../utilities/getTechRadarJson";
 import ProjectModal from "../components/Projects/ProjectModal";
@@ -350,10 +346,20 @@ function RadarPage() {
         "Language_Main",
         "Language_Others",
         "Language_Frameworks",
-        "Languages",
-        "Frameworks",
         "Infrastructure",
         "CICD",
+        "Cloud_Services",
+        "IAM_Services",
+        "Testing_Frameworks",
+        "Containers",
+        "Static_Analysis",
+        "Code_Formatter",
+        "Monitoring",
+        "Datastores",
+        "Data_Output_Formats",
+        "Integrations_ONS",
+        "Integrations_External",
+        "Database_Technologies",
       ];
 
       return allTechColumns.some((column) => {

--- a/frontend/src/styles/App.css
+++ b/frontend/src/styles/App.css
@@ -1179,7 +1179,6 @@ foreignObject {
   position: relative;
   padding-top: 4px;
 }
-
 .timeline-node {
   padding: 2px 12px;
   box-sizing: border-box;
@@ -1188,12 +1187,14 @@ foreignObject {
   font-weight: 500;
   cursor: pointer;
   position: relative;
-  white-space: nowrap;
+  white-space: normal;
   transition: all 0.2s ease;
   user-select: none;
   display: flex;
   align-items: center;
   gap: 6px;
+  max-width: 300px;
+  overflow-y: auto;
 }
 
 .timeline-movement {

--- a/frontend/src/styles/components/ProjectModal.css
+++ b/frontend/src/styles/components/ProjectModal.css
@@ -203,7 +203,6 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
-  min-height: 400px;
   height: calc(80vh - 200px);
   overflow-y: auto;
   padding-right: 8px;

--- a/terraform/service/iam.tf
+++ b/terraform/service/iam.tf
@@ -31,7 +31,7 @@ resource "aws_iam_role_policy" "task_logs_policy" {
           "logs:PutLogEvents",
           "logs:DescribeLogStreams"
         ]
-        Resource = "arn:aws:logs:eu-west-2:${var.aws_account_id}:log-group:/ecs/ecs-service-tech-radar-*:*"
+        Resource = "arn:aws:logs:eu-west-2:${var.aws_account_id}:log-group:/ecs/ecs-service-*:*"
       }
     ]
   })
@@ -62,4 +62,4 @@ resource "aws_iam_role_policy" "s3_read_only" {
       }
     ]
   })
-} 
+}


### PR DESCRIPTION
Clicking on a project in projects shows a project modal. A technology (Postgres in Databases) was highlighted, but then when clicking on the tech on the project modal, it would take you to the Radar like it should, but there would be no projects listed in the info-box. This is because we define what columns to look at in the project data. Just needed to copy the list from:

ProjectModal.js Line 202 to RadarPage.js Line 346:
``` javascript
  const technologyListFields = [
    "Language_Main",
    "Language_Others",
    "Language_Frameworks",
    "Infrastructure",
    "CICD",
    "Cloud_Services",
    "IAM_Services",
    "Testing_Frameworks",
    "Containers",
    "Static_Analysis",
    "Code_Formatter",
    "Monitoring",
    "Datastores",
    "Data_Output_Formats",
    "Integrations_ONS",
    "Integrations_External",
    "Database_Technologies",
  ];
```

--- 

Backend log was predefined resource:
```diff
-        Resource = "arn:aws:logs:eu-west-2:${var.aws_account_id}:log-group:/ecs/ecs-service-tech-radar:*"
```

```diff
+        Resource = "arn:aws:logs:eu-west-2:${var.aws_account_id}:log-group:/ecs/ecs-service-*:*"
```