### PR TITLE
Statistics tech radar only toggle ignore review and ignore

### DIFF
--- a/frontend/src/components/Statistics/Statistics.js
+++ b/frontend/src/components/Statistics/Statistics.js
@@ -151,7 +151,7 @@ function Statistics({
 
       if (showTechRadarOnly) {
         const status = getTechnologyStatus(language);
-        return matchesSearch && status !== null;
+        return matchesSearch && status !== null && status !== 'review' && status !== 'ignore';
       }
 
       return matchesSearch;


### PR DESCRIPTION
When clicking the 'Tech Radar Only' toggle it would show any tech that is in any ring. This change ignore those tech in 'ignore' or 'review'.