### PR TITLE
KEH-721 - Reduce memory and cpu

### DIFF
--- a/terraform/service/variables.tf
+++ b/terraform/service/variables.tf
@@ -64,13 +64,13 @@ variable "domain_extension" {
 variable "service_cpu" {
   description = "Service CPU"
   type        = string
-  default     = 2048
+  default     = 1024
 }
 
 variable "service_memory" {
   description = "Service memory"
   type        = string
-  default     = 4096
+  default     = 3072
 }
 
 variable "task_count" {


### PR DESCRIPTION
cpu: 2048 -> 1024
memory: 4096 -> 3072

### Important

AWS alerts the account that this application can be reduced to a memory of 2048, however:

This application uses a lot of memory and Fargate only has certain configurations of memory + cpu.

- cpu 1024 and memory 2048 will cause the task to fail as it runs out of memory
- cpu 1536 and memory 3072 does not exist in the Fargate config
- **cpu 1024 and memory 3072 is the only one that works**

As the application grows, the memory may have to be reverted back to 4096.