### PR TITLE
KEH-914 - Fix tech link for other tech

### DIFF
--- a/frontend/src/components/Projects/ProjectModal.js
+++ b/frontend/src/components/Projects/ProjectModal.js
@@ -284,13 +284,22 @@ const ProjectModal = ({
     "Testing_Frameworks",
     "Containers",
     "Static_Analysis",
+    "Source_Control",
     "Code_Formatter",
     "Monitoring",
     "Datastores",
+    "Database_Technologies",
     "Data_Output_Formats",
     "Integrations_ONS",
     "Integrations_External",
-    "Database_Technologies",
+    "Project_Tools",
+    "Code_Editors",
+    "Communication",
+    "Collaboration",
+    "Incident_Management",
+    "Documentation_Tools",
+    "UI_Tools",
+    "Diagram_Tools",
   ];
 
   const filterItems = (items) => {

--- a/frontend/src/pages/RadarPage.js
+++ b/frontend/src/pages/RadarPage.js
@@ -350,13 +350,22 @@ function RadarPage() {
         "Testing_Frameworks",
         "Containers",
         "Static_Analysis",
+        "Source_Control",
         "Code_Formatter",
         "Monitoring",
         "Datastores",
+        "Database_Technologies",
         "Data_Output_Formats",
         "Integrations_ONS",
         "Integrations_External",
-        "Database_Technologies",
+        "Project_Tools",
+        "Code_Editors",
+        "Communication",
+        "Collaboration",
+        "Incident_Management",
+        "Documentation_Tools",
+        "UI_Tools",
+        "Diagram_Tools",
       ];
 
       return allTechColumns.some((column) => {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

Changed the technologyListFields on projectModal.js and allTechColumns on RadarPages.js. This fixes the project modal not highlighting source control or any collaboration tools and also fixes not showing linked projects for source control or collaboration tools within the info box.

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [x] No
User testing was performed, but I this did not change any backend.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [ ] Yes
- [x] No
More of a config change rather than feature change.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Related issues

None.

### How to review

Load onto the dev environment and check the project modal and the info box for example 'Visual Studio Code' and 'GitHub'.