### PR TITLE
KEH-939 - Reset selected timeline item when tech changes

### DIFF
--- a/frontend/src/components/InfoBox/InfoBox.js
+++ b/frontend/src/components/InfoBox/InfoBox.js
@@ -102,6 +102,13 @@ const InfoBox = ({
     }
   }, [selectedItem]);
 
+  // Reset selected timeline item when selected technology changes
+  useEffect(() => {
+    if (setSelectedTimelineItem) {
+      setSelectedTimelineItem(null);
+    }
+  }, [selectedItem, setSelectedTimelineItem]);
+
   const handleEditClick = () => {
     setEditedTitle(selectedItem.title);
     setEditedCategory(selectedItem.description);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

This fix adds a new useEffect hook in the InfoBox component that resets the selectedTimelineItem to null whenever the selectedItem (technology) changes.

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [x] No
Please write a brief description of why test coverage is not necessary here.
- [x] Not as part of this ticket. (Could be done at a later point)

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [ ] Yes
- [x] No
Please write a brief description of why documentation is not necessary here.
- [x] Not as part of this ticket. (Could be done at a later point)

### Related issues

~~Provide links to any related issues.~~

### How to review

Just one hook has been added. Follow instructions in README to run locally.
