### PR TITLE
KEH-879-PATCH-1 - Add COPILOT_BUCKET_NAME to env vars

### DIFF
--- a/terraform/service/main.tf
+++ b/terraform/service/main.tf
@@ -103,6 +103,10 @@ resource "aws_ecs_task_definition" "ecs_service_definition" {
         {
           name = "GITHUB_ORG",
           value = var.github_org,
+        },
+        {
+          name = "COPILOT_BUCKET_NAME",
+          value = var.copilot_bucket_name
         }
       ],
       logConfiguration = {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

Overlooked in review. Backend would default to the 'dev' version of the copilot bucket in S3.
