### PR TITLE
Bump Cognito module version to v1.1.1

### DIFF
--- a/terraform/authentication/main.tf
+++ b/terraform/authentication/main.tf
@@ -11,7 +11,7 @@ terraform {
 }
 
 module "cognito" {
-  source = "git::https://github.com/ONS-Innovation/keh-cognito-auth-tf-module.git?ref=v1.0.0"
+  source = "git::https://github.com/ONS-Innovation/keh-cognito-auth-tf-module.git?ref=v1.1.1"
 
   domain             = var.domain
   service_subdomain  = var.service_subdomain

--- a/terraform/authentication/variables.tf
+++ b/terraform/authentication/variables.tf
@@ -60,6 +60,20 @@ variable "domain_extension" {
   default     = "aws.onsdigital.uk"
 }
 
+variable "token_validity_values" {
+  description = "Token validity duration values"
+  type = object({
+    refresh_token = number
+    access_token  = number
+    id_token      = number
+  })
+  default = {
+    refresh_token = 30  # 30 days
+    access_token  = 3   # 3 hours
+    id_token      = 3   # 3 hours
+  }
+}
+
 locals {
   url         = "${var.domain}.${var.domain_extension}"
   service_url = "${var.service_subdomain}.${local.url}"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

### What

The Reviewer Cognito was using v1 of the Cognito auth module. This didn't include the token lifespan update. I updated the version to most recent and increased the lifespan of the token from 1 hour to 3 hours. I think this change is fine. A lot of the time people have the keep re-logging in as an hour isn't long enough.

### How to review

- Login to sdp-dev reviewer
- Wait 2hrs 59mins and refresh page
- You will still be logged in