### PR TITLE
KEH-1065 - Close p tag in markdown renderer

### DIFF
--- a/frontend/src/utilities/markdownRenderer.js
+++ b/frontend/src/utilities/markdownRenderer.js
@@ -26,7 +26,7 @@ export const renderSimpleMarkdown = (text) => {
   html = html.replace(/^## (.+)$/gm, '<h2 class="markdown-h2">$1</h2>');
   html = html.replace(/^# (.+)$/gm, '<h1 class="markdown-h1">$1</h1>');
 
-  html = html.replace(/\n/g, '<p>');
+  html = html.replace(/\n/g, '<p> </p>');
 
   return html;
 };


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

The p tag wasn't closing so any text after was being enclosed within the p tag, making the text look smaller.
