### PR TITLE
KEH-1157 | Fix Statistics Search

### DIFF
--- a/frontend/src/components/Header/Header.js
+++ b/frontend/src/components/Header/Header.js
@@ -85,7 +85,8 @@ function Header({
   // Only show search results dropdown on radar page
   const shouldShowSearchResults = () => {
     return (
-      (location.pathname === '/radar' | location.pathname === '/statistics') &&
+      (location.pathname === '/radar') |
+        (location.pathname === '/statistics') &&
       searchResults &&
       searchResults.length > 0
     );

--- a/frontend/src/components/Header/Header.js
+++ b/frontend/src/components/Header/Header.js
@@ -85,7 +85,7 @@ function Header({
   // Only show search results dropdown on radar page
   const shouldShowSearchResults = () => {
     return (
-      location.pathname === '/radar' &&
+      (location.pathname === '/radar' | location.pathname === '/statistics') &&
       searchResults &&
       searchResults.length > 0
     );

--- a/frontend/src/components/Header/Header.js
+++ b/frontend/src/components/Header/Header.js
@@ -85,8 +85,7 @@ function Header({
   // Only show search results dropdown on radar page
   const shouldShowSearchResults = () => {
     return (
-      (location.pathname === '/radar') |
-        (location.pathname === '/statistics') &&
+      (location.pathname === '/radar') &&
       searchResults &&
       searchResults.length > 0
     );

--- a/frontend/src/components/Header/Header.js
+++ b/frontend/src/components/Header/Header.js
@@ -85,7 +85,7 @@ function Header({
   // Only show search results dropdown on radar page
   const shouldShowSearchResults = () => {
     return (
-      (location.pathname === '/radar') &&
+      location.pathname === '/radar' &&
       searchResults &&
       searchResults.length > 0
     );

--- a/frontend/src/components/Statistics/Statistics.js
+++ b/frontend/src/components/Statistics/Statistics.js
@@ -33,7 +33,6 @@ function Statistics({
     direction: 'descending',
   });
 
-  const [isFiltersVisible, setIsFiltersVisible] = useState(false);
   const [selectedDate, setSelectedDate] = useState('all');
   const [hoveredLanguage, setHoveredLanguage] = useState(null);
   const [showTechRadarOnly, setShowTechRadarOnly] = useState(false);

--- a/frontend/src/components/Statistics/Statistics.js
+++ b/frontend/src/components/Statistics/Statistics.js
@@ -41,8 +41,6 @@ function Statistics({
   const [selectedProjects, setSelectedProjects] = useState([]);
   const [showTotalSize, setShowTotalSize] = useState(false);
 
-  const searchQuery = searchTerm;
-
   const dateOptions = [
     { value: 'all', label: 'All Time' },
     { value: '1', label: 'Last Month' },
@@ -141,7 +139,7 @@ function Statistics({
     let filtered = Object.entries(languageStats).filter(([language]) => {
       const matchesSearch = language
         .toLowerCase()
-        .includes(searchQuery.toLowerCase());
+        .includes(searchTerm.toLowerCase());
 
       if (showTechRadarOnly) {
         const status = getTechnologyStatus(language);
@@ -178,7 +176,7 @@ function Statistics({
     return filtered;
   }, [
     getCurrentLanguageStats,
-    searchQuery,
+    searchTerm,
     sortConfig,
     getTechnologyStatus,
     showTechRadarOnly,

--- a/frontend/src/components/Statistics/Statistics.js
+++ b/frontend/src/components/Statistics/Statistics.js
@@ -33,7 +33,6 @@ function Statistics({
     direction: 'descending',
   });
 
-  const searchQuery = searchTerm;
   const [isFiltersVisible, setIsFiltersVisible] = useState(false);
   const [selectedDate, setSelectedDate] = useState('all');
   const [hoveredLanguage, setHoveredLanguage] = useState(null);
@@ -41,6 +40,8 @@ function Statistics({
   const [repoView, setRepoView] = useState('unarchived'); // 'unarchived', 'archived', 'total'
   const [selectedProjects, setSelectedProjects] = useState([]);
   const [showTotalSize, setShowTotalSize] = useState(false);
+
+  const searchQuery = searchTerm;
 
   const dateOptions = [
     { value: 'all', label: 'All Time' },

--- a/frontend/src/components/Statistics/Statistics.js
+++ b/frontend/src/components/Statistics/Statistics.js
@@ -32,7 +32,8 @@ function Statistics({
     key: 'repo_count',
     direction: 'descending',
   });
-  const [searchQuery, setSearchQuery] = useState(searchTerm);
+
+  const searchQuery = searchTerm;
   const [isFiltersVisible, setIsFiltersVisible] = useState(false);
   const [selectedDate, setSelectedDate] = useState('all');
   const [hoveredLanguage, setHoveredLanguage] = useState(null);

--- a/frontend/src/pages/StatisticsPage.js
+++ b/frontend/src/pages/StatisticsPage.js
@@ -207,9 +207,6 @@ function StatisticsPage() {
   const handleTechClick = tech => {
     const status = getTechnologyStatus(tech);
 
-    console.log('Clicked technology:', tech);
-    console.log('Technology status:', status);
-
     if (status && status !== 'review' && status !== 'ignore') {
       navigate('/radar', { state: { selectedTech: tech } });
     } else {

--- a/frontend/src/pages/StatisticsPage.js
+++ b/frontend/src/pages/StatisticsPage.js
@@ -5,7 +5,6 @@ import Header from '../components/Header/Header';
 import { toast } from 'react-hot-toast';
 import { useData } from '../contexts/dataContext';
 import { BannerContainer } from '../components/Banner';
-import { useTechnologyStatus } from '../utilities/getTechnologyStatus';
 
 /**
  * StatisticsPage component for displaying the statistics page.
@@ -201,20 +200,8 @@ function StatisticsPage() {
     setCurrentRepoView(repoView);
   };
 
-  // Use our custom hook instead of local implementation
-  const getTechnologyStatus = useTechnologyStatus();
-
   const handleTechClick = tech => {
-    const status = getTechnologyStatus(tech);
-
-    if (status && status !== 'review' && status !== 'ignore') {
-      navigate('/radar', { state: { selectedTech: tech } });
-    } else {
-      toast.error(
-        `Cannot view ${tech} details as it does not have a Radar entry.`,
-        { duration: 6000 }
-      );
-    }
+    navigate('/radar', { state: { selectedTech: tech } });
   };
 
   const handleProjectsChange = repositories => {
@@ -228,41 +215,11 @@ function StatisticsPage() {
     setSelectedRepositories(allRepoUrls);
   };
 
-  const getFilteredLanguages = () => {
-    if (!statsData) return [];
-
-    const languageStats = statsData.language_statistics_unarchived || {};
-    const languages = Object.entries(languageStats)
-      .filter(([language]) => {
-        return language.toLowerCase().includes(searchTerm.toLowerCase());
-      })
-      .map(([language, stats]) => ({
-        language,
-        ...stats,
-      }));
-
-    return languages;
-  };
-
-  const filteredLanguages = getFilteredLanguages();
-
-  // Convert filtered languages to search results format
-  // This is used for the search results in the header
-  // Must have a title property to be displayed in the search results modal
-
-  const searchResultsList = [];
-
-  filteredLanguages.forEach(language => {
-    searchResultsList.push({ title: language.language });
-  });
-
   return (
     <>
       <Header
         searchTerm={searchTerm}
         onSearchChange={value => setSearchTerm(value)}
-        searchResults={searchTerm ? searchResultsList : []}
-        onSearchResultClick={result => handleTechClick(result.title)}
       />
       <BannerContainer page="statistics" />
       <div className="statistics-page">

--- a/frontend/src/pages/StatisticsPage.js
+++ b/frontend/src/pages/StatisticsPage.js
@@ -5,6 +5,7 @@ import Header from '../components/Header/Header';
 import { toast } from 'react-hot-toast';
 import { useData } from '../contexts/dataContext';
 import { BannerContainer } from '../components/Banner';
+import { useTechnologyStatus } from '../utilities/getTechnologyStatus';
 
 /**
  * StatisticsPage component for displaying the statistics page.
@@ -200,8 +201,21 @@ function StatisticsPage() {
     setCurrentRepoView(repoView);
   };
 
+  // Use our custom hook instead of local implementation
+  const getTechnologyStatus = useTechnologyStatus();
+
   const handleTechClick = tech => {
-    navigate('/radar', { state: { selectedTech: tech } });
+    const status = getTechnologyStatus(tech);
+
+    console.log('Clicked technology:', tech);
+    console.log('Technology status:', status);
+
+    if (status && status !== 'review' && status !== 'ignore') {
+      navigate('/radar', { state: { selectedTech: tech } });
+    }
+    else {
+      toast.error(`Cannot view ${tech} details as it does not have a Radar entry.`, { duration: 6000 });
+    }
   };
 
   const handleProjectsChange = repositories => {

--- a/frontend/src/pages/StatisticsPage.js
+++ b/frontend/src/pages/StatisticsPage.js
@@ -233,13 +233,23 @@ function StatisticsPage() {
 
   const filteredLanguages = getFilteredLanguages();
 
+  // Convert filtered languages to search results format
+  // This is used for the search results in the header
+  // Must have a title property to be displayed in the search results modal
+
+  const searchResultsList = [];
+  
+  filteredLanguages.forEach(language => {
+    searchResultsList.push({"title": language.language});
+  });
+
   return (
     <>
       <Header
         searchTerm={searchTerm}
         onSearchChange={value => setSearchTerm(value)}
-        searchResults={[]}
-        onSearchResultClick={result => handleTechClick(result.language)}
+        searchResults={searchTerm ? searchResultsList : []}
+        onSearchResultClick={result => handleTechClick(result.title)}
       />
       <BannerContainer page="statistics" />
       <div className="statistics-page">

--- a/frontend/src/pages/StatisticsPage.js
+++ b/frontend/src/pages/StatisticsPage.js
@@ -212,9 +212,11 @@ function StatisticsPage() {
 
     if (status && status !== 'review' && status !== 'ignore') {
       navigate('/radar', { state: { selectedTech: tech } });
-    }
-    else {
-      toast.error(`Cannot view ${tech} details as it does not have a Radar entry.`, { duration: 6000 });
+    } else {
+      toast.error(
+        `Cannot view ${tech} details as it does not have a Radar entry.`,
+        { duration: 6000 }
+      );
     }
   };
 
@@ -252,9 +254,9 @@ function StatisticsPage() {
   // Must have a title property to be displayed in the search results modal
 
   const searchResultsList = [];
-  
+
   filteredLanguages.forEach(language => {
-    searchResultsList.push({"title": language.language});
+    searchResultsList.push({ title: language.language });
   });
 
   return (


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

Statistics search was broken. Nothing would happen when adding input.

The search input now does the following:

- Displays a list of search results as you type in your search query.
- Filter the statistics cards to only be languages that fit the search query.
- Redirects to radar entry when clicking a language within search results.
- If the search result language is on hold or in review and clicked, displays an error toast to inform the user.

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [x] No
Please write a brief description of why test coverage is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

**I am unsure if anything needs updating**

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [ ] Yes
- [x] No
Please write a brief description of why documentation is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

**I am unsure if anything needs updating**

### Related issues

KEH-1157 on Jira.

### How to review

1. Pull down repo.
2. Export env vars.
3. Run tool locally.
4. Use statistics search.

### Notes

I am unsure if displaying search results **and** filtering the statistics cards is necessary. Want some thoughts on this.

First Digiland contribution 🎉 
