### PR TITLE
KEH-1122 - Add Admin Copilot View

### DIFF
--- a/backend/src/routes/copilot.js
+++ b/backend/src/routes/copilot.js
@@ -2,6 +2,7 @@ const logger = require('../config/logger');
 const express = require('express');
 const s3Service = require('../services/s3Service');
 const githubService = require('../services/githubService');
+const { checkCopilotAdminStatus } = require('../utilities/copilotAdminChecker');
 
 const router = express.Router();
 
@@ -81,8 +82,21 @@ router.get('/team/live', async (req, res) => {
   }
 
   try {
-    const data = await githubService.getCopilotTeamMetrics(teamSlug, userToken);
-    res.json(data);
+    // Check if user is copilot admin
+    const adminStatus = await checkCopilotAdminStatus(userToken);
+
+    if (adminStatus.isAdmin) {
+      // Copilot admin can view any team, use app installation
+      const data = await githubService.getCopilotTeamMetricsAsAdmin(teamSlug);
+      res.json(data);
+    } else {
+      // Regular user, check team membership
+      const data = await githubService.getCopilotTeamMetrics(
+        teamSlug,
+        userToken
+      );
+      res.json(data);
+    }
   } catch (error) {
     logger.error('GitHub API error:', { error: error.message });
     res.status(500).json({ error: error.message });
@@ -106,7 +120,33 @@ router.get('/seats', async (req, res) => {
 });
 
 /**
- * Endpoint for fetching teams the authenticated user is a member of in the organisation from the GitHub API.
+ * Endpoint for checking if the authenticated user is a copilot admin
+ * @route GET /copilot/api/admin/status
+ * @returns {Object} Copilot admin status and available teams
+ * @throws {Error} 401 - If user token is missing
+ * @throws {Error} 500 - If checking fails
+ */
+router.get('/admin/status', async (req, res) => {
+  const userToken = req.cookies?.githubUserToken;
+
+  if (!userToken) {
+    return res.status(401).json({ error: 'Missing GitHub user token' });
+  }
+
+  try {
+    const adminStatus = await checkCopilotAdminStatus(userToken);
+    res.json(adminStatus);
+  } catch (error) {
+    logger.error('Error checking copilot admin status:', {
+      error: error.message,
+    });
+    res.status(500).json({ error: error.message });
+  }
+});
+
+/**
+ * Endpoint for fetching teams the authenticated user can view.
+ * Returns user's teams if they're not a copilot admin, or copilot teams if they are.
  * @route GET /copilot/api/teams
  * @returns {Object} Copilot teams JSON data
  * @throws {Error} 401 - If user token is missing
@@ -120,8 +160,11 @@ router.get('/teams', async (req, res) => {
   }
 
   try {
-    const teams = await githubService.getUserTeams(userToken);
-    res.json(teams);
+    const adminStatus = await checkCopilotAdminStatus(userToken);
+    res.json({
+      teams: adminStatus.teams,
+      isAdmin: adminStatus.isAdmin,
+    });
   } catch (error) {
     logger.error('GitHub API error:', { error: error.message });
     res.status(500).json({ error: error.message });
@@ -147,9 +190,14 @@ router.get('/team/seats', async (req, res) => {
   }
 
   try {
+    // Check if user is copilot admin
+    const adminStatus = await checkCopilotAdminStatus(userToken);
+
     const [allSeats, members] = await Promise.all([
       githubService.getCopilotSeats(),
-      githubService.getTeamMembers(teamSlug, userToken),
+      adminStatus.isAdmin
+        ? githubService.getTeamMembersAsAdmin(teamSlug)
+        : githubService.getTeamMembers(teamSlug, userToken),
     ]);
 
     const memberIds = new Set(members.map(m => m.id));

--- a/backend/src/services/githubService.js
+++ b/backend/src/services/githubService.js
@@ -194,6 +194,64 @@ class GitHubService {
       throw error;
     }
   }
+
+  /**
+   * Get GitHub Copilot team metrics as admin (using app installation)
+   * @param {string} teamSlug - The slug of the team to fetch metrics for
+   * @returns {Promise<Object>} Team metrics data
+   */
+  async getCopilotTeamMetricsAsAdmin(teamSlug) {
+    try {
+      const octokit = await getAppAndInstallation();
+
+      const response = await octokit.request(
+        `GET /orgs/${this.org}/teams/${teamSlug}/copilot/metrics`,
+        {
+          headers: {
+            'X-GitHub-Api-Version': '2022-11-28',
+          },
+        }
+      );
+
+      return response.data;
+    } catch (error) {
+      logger.error(
+        'GitHub API error while fetching Copilot team metrics as admin:',
+        {
+          error: error.message,
+        }
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Get team members as admin (using app installation)
+   * @param {string} teamSlug - The slug of the team to fetch members for
+   * @returns {Promise<Array>} Array of team members
+   */
+  async getTeamMembersAsAdmin(teamSlug) {
+    try {
+      const octokit = await getAppAndInstallation();
+
+      const response = await octokit.request(
+        `GET /orgs/${this.org}/teams/${teamSlug}/members`,
+        {
+          headers: {
+            'X-GitHub-Api-Version': '2022-11-28',
+          },
+          per_page: 100,
+        }
+      );
+
+      return response.data || [];
+    } catch (error) {
+      logger.error('GitHub API error while fetching team members as admin:', {
+        error: error.message,
+      });
+      throw error;
+    }
+  }
 }
 
 // Export a singleton instance

--- a/backend/src/utilities/copilotAdminChecker.js
+++ b/backend/src/utilities/copilotAdminChecker.js
@@ -43,18 +43,11 @@ async function checkCopilotAdminStatus(userToken) {
       try {
         const copilotBucketName =
           process.env.COPILOT_BUCKET_NAME || 'sdp-dev-copilot-usage-dashboard';
-        const copilotTeamSlugs = await s3Service.getObject(
+        copilotTeams = await s3Service.getObject(
           copilotBucketName,
           'copilot_teams.json'
         );
 
-        // Copilot lambda needs changing to get full team data
-        copilotTeams = copilotTeamSlugs.map(slug => ({
-          slug: slug,
-          name: slug, // Use slug as name since we dont have the full team data
-          description: null,
-          url: `https://github.com/orgs/${process.env.GITHUB_ORG || 'ONSdigital'}/teams/${slug}`,
-        }));
       } catch (error) {
         logger.warn('Could not fetch copilot_teams.json from S3:', {
           error: error.message,

--- a/backend/src/utilities/copilotAdminChecker.js
+++ b/backend/src/utilities/copilotAdminChecker.js
@@ -1,0 +1,87 @@
+const s3Service = require('../services/s3Service');
+const githubService = require('../services/githubService');
+const logger = require('../config/logger');
+
+/**
+ * Check if a user is a copilot admin by comparing their teams with admin teams
+ * @param {string} userToken - GitHub access token for the user
+ * @returns {Promise<Object>} Object containing isAdmin boolean and available teams
+ */
+async function checkCopilotAdminStatus(userToken) {
+  try {
+    // Get user's teams
+    const userTeams = await githubService.getUserTeams(userToken);
+    const userTeamSlugs = userTeams.map(team => team.slug);
+
+    // Get admin teams from S3
+    let adminTeams = [];
+    try {
+      const copilotBucketName =
+        process.env.COPILOT_BUCKET_NAME || 'sdp-dev-copilot-usage-dashboard';
+      adminTeams = await s3Service.getObject(
+        copilotBucketName,
+        'admin_teams.json'
+      );
+    } catch (error) {
+      logger.warn('Could not fetch admin_teams.json from S3:', {
+        error: error.message,
+      });
+      return {
+        isAdmin: false,
+        teams: userTeams,
+      };
+    }
+
+    // Check if user is in any admin team
+    const isAdmin = adminTeams.some(adminTeam =>
+      userTeamSlugs.includes(adminTeam)
+    );
+
+    if (isAdmin) {
+      // User is admin, get copilot teams
+      let copilotTeams = [];
+      try {
+        const copilotBucketName =
+          process.env.COPILOT_BUCKET_NAME || 'sdp-dev-copilot-usage-dashboard';
+        const copilotTeamSlugs = await s3Service.getObject(
+          copilotBucketName,
+          'copilot_teams.json'
+        );
+
+        // Copilot lambda needs changing to get full team data
+        copilotTeams = copilotTeamSlugs.map(slug => ({
+          slug: slug,
+          name: slug, // Use slug as name since we dont have the full team data
+          description: null,
+          url: `https://github.com/orgs/${process.env.GITHUB_ORG || 'ONSdigital'}/teams/${slug}`,
+        }));
+      } catch (error) {
+        logger.warn('Could not fetch copilot_teams.json from S3:', {
+          error: error.message,
+        });
+        // Fallback to user teams
+        copilotTeams = userTeams;
+      }
+
+      return {
+        isAdmin: true,
+        teams: copilotTeams,
+      };
+    } else {
+      // User is not admin, return their regular teams
+      return {
+        isAdmin: false,
+        teams: userTeams,
+      };
+    }
+  } catch (error) {
+    logger.error('Error checking copilot admin status:', {
+      error: error.message,
+    });
+    throw error;
+  }
+}
+
+module.exports = {
+  checkCopilotAdminStatus,
+};

--- a/frontend/src/components/Copilot/Dashboards/LiveDashboard.js
+++ b/frontend/src/components/Copilot/Dashboards/LiveDashboard.js
@@ -64,7 +64,6 @@ function LiveDashboard({
           seat statistics being viewable on the dashboard.
         </p>
       )}
-      <h1 className="title">IDE Code Completions</h1>
       {isLiveLoading ? (
         <div className="copilot-grid">
           <SkeletonStatCard />
@@ -75,9 +74,12 @@ function LiveDashboard({
           <SkeletonStatCard />
         </div>
       ) : (
-        <div>
-          <CompletionsCards completions={completions} prefix={'Total'} />
-        </div>
+        completions.length > 0 && (
+          <div>
+            <h1 className="title">IDE Code Completions</h1>
+            <CompletionsCards completions={completions} prefix={'Total'} />
+          </div>
+        )
       )}
       {isLiveLoading ? (
         <h3>Loading live data...</h3>
@@ -95,24 +97,24 @@ function LiveDashboard({
               <EngagedUsersGraph data={completions?.perGroupedPeriod} />
             </div>
           )}
-          <div className="copilot-charts-container">
-            {completions &&
-              Object.keys(completions.engagedUsersByLanguage || {}).length >
-                0 && (
+          {completions &&
+            ((Object.keys(completions.engagedUsersByLanguage || {}).length > 0) ||
+             (Object.keys(completions.engagedUsersByEditor || {}).length > 0)) && (
+            <div className="copilot-charts-container">
+              {Object.keys(completions.engagedUsersByLanguage || {}).length > 0 && (
                 <PieChart
                   engagedUsers={completions?.engagedUsersByLanguage}
                   title={'Engaged Users by Language'}
                 />
               )}
-            {completions &&
-              Object.keys(completions.engagedUsersByEditor || {}).length >
-                0 && (
+              {Object.keys(completions.engagedUsersByEditor || {}).length > 0 && (
                 <PieChart
                   engagedUsers={completions?.engagedUsersByEditor}
                   title={'Engaged Users by Editor'}
                 />
               )}
-          </div>
+            </div>
+          )}
           {completions &&
             Object.keys(completions.languageBreakdown || {}).length > 0 && (
               <div>
@@ -152,20 +154,25 @@ function LiveDashboard({
         </div>
       )}
 
-      <h1 className="title">Copilot Chat</h1>
-      {isLiveLoading ? (
-        <div className="copilot-chat-grid">
-          <SkeletonStatCard />
-          <SkeletonStatCard />
-          <SkeletonStatCard />
-          <SkeletonStatCard />
-          <SkeletonStatCard />
-        </div>
-      ) : (
-        <div>
-          <ChatCards chats={chats} prefix={'Total'} />
-        </div>
+      {chats && chats.perGroupedPeriod.length > 0 && (
+        <>
+          <h1 className="title">Copilot Chat</h1>
+          {isLiveLoading ? (
+            <div className="copilot-chat-grid">
+              <SkeletonStatCard />
+              <SkeletonStatCard />
+              <SkeletonStatCard />
+              <SkeletonStatCard />
+              <SkeletonStatCard />
+            </div>
+          ) : (
+            <div>
+              <ChatCards chats={chats} prefix={'Total'} />
+            </div>
+          )}
+        </>
       )}
+
       {isLiveLoading ? (
         <h3>Loading live data...</h3>
       ) : (
@@ -176,15 +183,17 @@ function LiveDashboard({
               <EngagedUsersGraph data={chats?.perGroupedPeriod} />
             </div>
           )}
-          <div className="copilot-charts-container">
-            {chats &&
-              Object.keys(chats.engagedUsersByEditor || {}).length > 0 && (
+
+          {chats &&
+            Object.keys(chats.engagedUsersByEditor || {}).length > 0 && (
+              <div className="copilot-charts-container">
                 <PieChart
                   engagedUsers={chats?.engagedUsersByEditor}
                   title={'Engaged Users by Editor'}
                 />
-              )}
-          </div>
+              </div>
+            )}
+
           {chats && Object.keys(chats.editorBreakdown || {}).length > 0 && (
             <div>
               <h3>Editor Breakdown</h3>

--- a/frontend/src/components/Copilot/Dashboards/LiveDashboard.js
+++ b/frontend/src/components/Copilot/Dashboards/LiveDashboard.js
@@ -74,7 +74,7 @@ function LiveDashboard({
           <SkeletonStatCard />
         </div>
       ) : (
-        completions.length > 0 && (
+        completions?.length > 0 && (
           <div>
             <h1 className="title">IDE Code Completions</h1>
             <CompletionsCards completions={completions} prefix={'Total'} />
@@ -98,23 +98,26 @@ function LiveDashboard({
             </div>
           )}
           {completions &&
-            ((Object.keys(completions.engagedUsersByLanguage || {}).length > 0) ||
-             (Object.keys(completions.engagedUsersByEditor || {}).length > 0)) && (
-            <div className="copilot-charts-container">
-              {Object.keys(completions.engagedUsersByLanguage || {}).length > 0 && (
-                <PieChart
-                  engagedUsers={completions?.engagedUsersByLanguage}
-                  title={'Engaged Users by Language'}
-                />
-              )}
-              {Object.keys(completions.engagedUsersByEditor || {}).length > 0 && (
-                <PieChart
-                  engagedUsers={completions?.engagedUsersByEditor}
-                  title={'Engaged Users by Editor'}
-                />
-              )}
-            </div>
-          )}
+            (Object.keys(completions.engagedUsersByLanguage || {}).length > 0 ||
+              Object.keys(completions.engagedUsersByEditor || {}).length >
+                0) && (
+              <div className="copilot-charts-container">
+                {Object.keys(completions.engagedUsersByLanguage || {}).length >
+                  0 && (
+                  <PieChart
+                    engagedUsers={completions?.engagedUsersByLanguage}
+                    title={'Engaged Users by Language'}
+                  />
+                )}
+                {Object.keys(completions.engagedUsersByEditor || {}).length >
+                  0 && (
+                  <PieChart
+                    engagedUsers={completions?.engagedUsersByEditor}
+                    title={'Engaged Users by Editor'}
+                  />
+                )}
+              </div>
+            )}
           {completions &&
             Object.keys(completions.languageBreakdown || {}).length > 0 && (
               <div>

--- a/frontend/src/pages/CopilotPage.js
+++ b/frontend/src/pages/CopilotPage.js
@@ -189,6 +189,7 @@ function CopilotDashboard() {
   const [isTeamLoading, setIsTeamLoading] = useState(false);
   const [teamSlug, setTeamSlug] = useState(null);
   const [isInitialised, setIsInitialised] = useState(false);
+  const [isCopilotAdmin, setIsCopilotAdmin] = useState(false);
 
   const data = getDashboardData();
 
@@ -316,9 +317,10 @@ function CopilotDashboard() {
         const isAuthenticated = await checkAuthStatus();
         if (isAuthenticated) {
           setIsAuthenticated(true);
-          const teams = await fetchUserTeams();
-          if (teams && teams.length >= 0) {
-            setAvailableTeams(teams);
+          const teamsData = await fetchUserTeams();
+          if (teamsData && teamsData.teams && teamsData.teams.length >= 0) {
+            setAvailableTeams(teamsData.teams);
+            setIsCopilotAdmin(teamsData.isAdmin);
           }
         } else {
           setIsAuthenticated(false);
@@ -415,6 +417,7 @@ function CopilotDashboard() {
       await logoutUser();
       setIsAuthenticated(false);
       setAvailableTeams([]);
+      setIsCopilotAdmin(false);
       setTeamSlug(null);
       setIsSelectingTeam(true);
       navigate('/copilot/team', { replace: true });
@@ -571,9 +574,16 @@ function CopilotDashboard() {
           {scope === 'team' && isSelectingTeam ? (
             <>
               <div className="team-selection-header">
-                <p className="header-text" style={{ margin: '0' }}>
-                  Select a Team to View
-                </p>
+                <div>
+                  <p className="header-text" style={{ margin: '0' }}>
+                    Select a Team to View
+                  </p>
+                  {isCopilotAdmin && (
+                    <p className="copilot-admin-badge">
+                      Copilot Admin - You can view all configured teams
+                    </p>
+                  )}
+                </div>
                 {isAuthenticated && (
                   <button
                     type="button"
@@ -633,9 +643,9 @@ function CopilotDashboard() {
                     </div>
                   ) : (
                     <p>
-                      No teams available. Please ensure you are a member of at
-                      least one team in the organisation with more than 5 active
-                      Copilot licenses.
+                      {isCopilotAdmin
+                        ? 'No teams available. Please ensure the copilot_teams.json file is configured with team names in S3.'
+                        : 'No teams available. Please ensure you are a member of at least one team in the organisation with more than 5 active Copilot licenses.'}
                     </p>
                   )}
                 </div>
@@ -651,9 +661,9 @@ function CopilotDashboard() {
                 </div>
               )}
               <p className="disclaimer-banner">
-                The GitHub API does not return Copilot team usage data if there
-                are fewer than 5 members with Copilot licenses. This may result
-                in only seat statistics being viewable on the dashboard.
+                {isCopilotAdmin
+                  ? 'As a Copilot Admin, you can view any valid team. The GitHub API does not return Copilot team usage data if there are fewer than 5 members with Copilot licenses.'
+                  : 'The GitHub API does not return Copilot team usage data if there are fewer than 5 members with Copilot licenses. This may result in only seat statistics being viewable on the dashboard.'}
               </p>
             </>
           ) : viewMode === 'live' ? (

--- a/frontend/src/styles/CopilotPage.css
+++ b/frontend/src/styles/CopilotPage.css
@@ -21,7 +21,6 @@
   background-color: hsl(210, 100%, 97%);
   border: 1px solid hsl(210, 100%, 50%);
   color: hsl(210, 100%, 20%);
-  margin-bottom: 0;
   padding: 8px 12px;
   border-radius: var(--radius);
   box-sizing: border-box;

--- a/frontend/src/styles/CopilotPage.css
+++ b/frontend/src/styles/CopilotPage.css
@@ -488,8 +488,15 @@
 .team-selection-header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   margin-bottom: 16px;
+}
+
+.copilot-admin-badge {
+  font-size: 12px;
+  color: hsl(var(--primary));
+  margin: 4px 0 0 0;
+  font-weight: 500;
 }
 
 .github-logout-button {

--- a/frontend/src/utilities/getTeams.js
+++ b/frontend/src/utilities/getTeams.js
@@ -21,8 +21,8 @@ export const checkAuthStatus = async () => {
 };
 
 /**
- * Fetch Github teams the authenticated user is a member of in the organisation
- * @returns {Promise<Array>} Array of teams
+ * Fetch teams the authenticated user can view (user teams or copilot admin teams)
+ * @returns {Promise<Object>} Object containing teams array and isAdmin boolean
  */
 export const fetchUserTeams = async () => {
   try {
@@ -37,14 +37,48 @@ export const fetchUserTeams = async () => {
         response.status,
         response.statusText
       );
-      return [];
+      return { teams: [], isAdmin: false };
     }
 
     const data = await response.json();
-    return data;
+    return {
+      teams: data.teams || [],
+      isAdmin: data.isAdmin || false,
+    };
   } catch (error) {
     console.error('Error fetching teams:', error);
-    return [];
+    return { teams: [], isAdmin: false };
+  }
+};
+
+/**
+ * Check copilot admin status for the authenticated user
+ * @returns {Promise<Object>} Object containing teams array and isAdmin boolean
+ */
+export const checkCopilotAdminStatus = async () => {
+  try {
+    const backendUrl = import.meta.env.VITE_BACKEND_URL || '';
+    const response = await fetch(`${backendUrl}/copilot/api/admin/status`, {
+      credentials: 'include',
+    });
+
+    if (!response.ok) {
+      console.error(
+        'Failed to check admin status:',
+        response.status,
+        response.statusText
+      );
+      return { teams: [], isAdmin: false };
+    }
+
+    const data = await response.json();
+    return {
+      teams: data.teams || [],
+      isAdmin: data.isAdmin || false,
+    };
+  } catch (error) {
+    console.error('Error checking admin status:', error);
+    return { teams: [], isAdmin: false };
   }
 };
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

### What

If a user is part of a team that is listed in admin_teams.json in the copilot S3 bucket, then they are given admin access. This means that they can see all the valid teams (teams only show data if they have 5+ active licenses). 

A design choice was to only show these teams with 5+ active licenses as supposed to every team in ONSDigital. For instance, if Team X had 10 active licenses including Person A and Person B, but then Team Y has only Person A and Person B in the team (2 members) then Team Y will not be shown in this admin section even though you would be able to view the seat data for Person A and B.

The valid copilot teams are enabled by this repo and PR which has been merged (https://github.com/ONS-Innovation/github-copilot-usage-dashboard/pull/52). On approval of this PR, I will redeploy the lambda on production.

The digital landscape **and** Copilot lambda changes are live on dev.

### Testing & Documentation

- [ ] Yes
- [x] No

Testing didn't need changing, as frontend testing runs over the /copilot/team page and backend still hits same endpoints.

### Related issues

https://github.com/ONS-Innovation/github-copilot-usage-dashboard/pull/52

### How to review

View on dev, or pull down and run make dev. View the /copilot/team page. Anyone in keh-dev should be able to view.