### PR TITLE
KEH-1310 - Contrast issue with dark mode

### DIFF
--- a/frontend/src/styles/components/Statistics.css
+++ b/frontend/src/styles/components/Statistics.css
@@ -3,6 +3,16 @@
   color: #222 !important;
 }
 
+@media (prefers-color-scheme: light) {
+  .ag-picker-field-display {
+    color: #222 !important;
+  }
+  .ag-picker-field-icon .ag-icon {
+    color: #222 !important;
+    fill: #222 !important;
+  }
+}
+
 @media (prefers-color-scheme: dark) {
   .ag-picker-field-display {
     color: #efeaea !important;
@@ -10,16 +20,6 @@
   .ag-picker-field-icon .ag-icon {
     color: #efeaea !important;
     fill: #efeaea !important;
-  }
-}
-/* AG Grid picker field display contrast fix for both themes */
-.ag-picker-field-display {
-  color: #222 !important;
-}
-
-@media (prefers-color-scheme: dark) {
-  .ag-picker-field-display {
-    color: #efeaea !important;
   }
 }
 

--- a/frontend/src/styles/components/Statistics.css
+++ b/frontend/src/styles/components/Statistics.css
@@ -1,3 +1,7 @@
+/* Increase contrast for AG Grid picker field display */
+.ag-picker-field-display {
+  color: #efeaea !important;
+}
 .statistics-page {
   width: 100%;
   height: 100%;

--- a/frontend/src/styles/components/Statistics.css
+++ b/frontend/src/styles/components/Statistics.css
@@ -1,26 +1,50 @@
-/* AG Grid picker field display contrast fix for both themes */
-.ag-picker-field-display {
-  color: #222 !important;
-}
+/* 0) One variable to rule them all */
+:root { --picker-fg: #222; } /* light default */
 
-@media (prefers-color-scheme: light) {
-  .ag-picker-field-display {
-    color: #222 !important;
-  }
-  .ag-picker-field-icon .ag-icon {
-    color: #222 !important;
-    fill: #222 !important;
-  }
-}
+/* Dark by class (Tailwind-style) */
+html.dark { --picker-fg: #efeaea; }
 
+/* Dark by OS preference (when no .dark override) */
 @media (prefers-color-scheme: dark) {
-  .ag-picker-field-display {
-    color: #efeaea !important;
-  }
-  .ag-picker-field-icon .ag-icon {
-    color: #efeaea !important;
-    fill: #efeaea !important;
-  }
+  :root { --picker-fg: #efeaea; }
+}
+
+/* --- Apply to AG Grid picker + icon, any theme --- */
+[class*="ag-theme-"] .ag-picker-field-wrapper .ag-picker-field-display,
+[class*="ag-theme-"] .ag-picker-field-wrapper .ag-picker-field-icon .ag-icon {
+  color: var(--picker-fg) !important;
+  fill: currentColor !important;
+}
+
+/* Align AG Grid vars so internals don’t fight you */
+[class*="ag-theme-"] {
+  --ag-foreground-color: var(--picker-fg);
+  --ag-input-text-color: var(--picker-fg);
+  --ag-icon-color: var(--picker-fg);
+}
+
+/* If collapsed/disabled dims via opacity, undo it */
+.ag-picker-field-wrapper.ag-picker-collapsed,
+.ag-picker-field-wrapper.ag-picker-field-disabled { opacity: 1 !important; }
+
+/* --- HARD LIGHT OVERRIDE (wins even if a *-dark theme class lingers) --- */
+/* Place this AFTER the blocks above */
+html:not(.dark) [class*="ag-theme-"] .ag-picker-field-wrapper .ag-picker-field-display,
+html:not(.dark) [class*="ag-theme-"] .ag-picker-field-wrapper .ag-picker-field-icon .ag-icon {
+  color: #222 !important;
+  fill: currentColor !important;
+}
+
+/* Apply your unified color to ALL ag-icon spans */
+[class*="ag-theme-"] .ag-icon {
+  color: var(--picker-fg) !important;
+  fill: currentColor !important;
+}
+
+/* Special case: force filter icon in light mode */
+html:not(.dark) [class*="ag-theme-"] .ag-icon.ag-icon-filter {
+  color: #222 !important;
+  fill: currentColor !important;
 }
 
 .statistics-page {

--- a/frontend/src/styles/components/Statistics.css
+++ b/frontend/src/styles/components/Statistics.css
@@ -1,7 +1,28 @@
-/* Increase contrast for AG Grid picker field display */
+/* AG Grid picker field display contrast fix for both themes */
 .ag-picker-field-display {
-  color: #efeaea !important;
+  color: #222 !important;
 }
+
+@media (prefers-color-scheme: dark) {
+  .ag-picker-field-display {
+    color: #efeaea !important;
+  }
+  .ag-picker-field-icon .ag-icon {
+    color: #efeaea !important;
+    fill: #efeaea !important;
+  }
+}
+/* AG Grid picker field display contrast fix for both themes */
+.ag-picker-field-display {
+  color: #222 !important;
+}
+
+@media (prefers-color-scheme: dark) {
+  .ag-picker-field-display {
+    color: #efeaea !important;
+  }
+}
+
 .statistics-page {
   width: 100%;
   height: 100%;

--- a/frontend/src/styles/components/Statistics.css
+++ b/frontend/src/styles/components/Statistics.css
@@ -1,23 +1,29 @@
 /* 0) One variable to rule them all */
-:root { --picker-fg: #222; } /* light default */
+:root {
+  --picker-fg: #222;
+} /* light default */
 
 /* Dark by class (Tailwind-style) */
-html.dark { --picker-fg: #efeaea; }
+html.dark {
+  --picker-fg: #efeaea;
+}
 
 /* Dark by OS preference (when no .dark override) */
 @media (prefers-color-scheme: dark) {
-  :root { --picker-fg: #efeaea; }
+  :root {
+    --picker-fg: #efeaea;
+  }
 }
 
 /* --- Apply to AG Grid picker + icon, any theme --- */
-[class*="ag-theme-"] .ag-picker-field-wrapper .ag-picker-field-display,
-[class*="ag-theme-"] .ag-picker-field-wrapper .ag-picker-field-icon .ag-icon {
+[class*='ag-theme-'] .ag-picker-field-wrapper .ag-picker-field-display,
+[class*='ag-theme-'] .ag-picker-field-wrapper .ag-picker-field-icon .ag-icon {
   color: var(--picker-fg) !important;
   fill: currentColor !important;
 }
 
 /* Align AG Grid vars so internals don’t fight you */
-[class*="ag-theme-"] {
+[class*='ag-theme-'] {
   --ag-foreground-color: var(--picker-fg);
   --ag-input-text-color: var(--picker-fg);
   --ag-icon-color: var(--picker-fg);
@@ -25,26 +31,84 @@ html.dark { --picker-fg: #efeaea; }
 
 /* If collapsed/disabled dims via opacity, undo it */
 .ag-picker-field-wrapper.ag-picker-collapsed,
-.ag-picker-field-wrapper.ag-picker-field-disabled { opacity: 1 !important; }
+.ag-picker-field-wrapper.ag-picker-field-disabled {
+  opacity: 1 !important;
+}
 
 /* --- HARD LIGHT OVERRIDE (wins even if a *-dark theme class lingers) --- */
 /* Place this AFTER the blocks above */
-html:not(.dark) [class*="ag-theme-"] .ag-picker-field-wrapper .ag-picker-field-display,
-html:not(.dark) [class*="ag-theme-"] .ag-picker-field-wrapper .ag-picker-field-icon .ag-icon {
+html:not(.dark)
+  [class*='ag-theme-']
+  .ag-picker-field-wrapper
+  .ag-picker-field-display,
+html:not(.dark)
+  [class*='ag-theme-']
+  .ag-picker-field-wrapper
+  .ag-picker-field-icon
+  .ag-icon {
   color: #222 !important;
   fill: currentColor !important;
 }
 
 /* Apply your unified color to ALL ag-icon spans */
-[class*="ag-theme-"] .ag-icon {
+[class*='ag-theme-'] .ag-icon {
   color: var(--picker-fg) !important;
   fill: currentColor !important;
 }
 
 /* Special case: force filter icon in light mode */
-html:not(.dark) [class*="ag-theme-"] .ag-icon.ag-icon-filter {
+html:not(.dark) [class*='ag-theme-'] .ag-icon.ag-icon-filter {
   color: #222 !important;
   fill: currentColor !important;
+}
+
+/* Shared vars (you already have these; included for clarity) */
+:root {
+  --picker-fg: #222;
+} /* light default */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --picker-fg: #efeaea;
+  } /* dark */
+}
+
+/* AG inputs: text, caret, and placeholder */
+[class*='ag-theme-'] .ag-input-field-input,
+[class*='ag-theme-'] input.ag-input-field-input.ag-text-field-input {
+  color: var(--picker-fg) !important;
+  caret-color: var(--picker-fg) !important;
+  background-color: transparent; /* or set a solid bg if needed */
+}
+
+/* Placeholder */
+[class*='ag-theme-'] .ag-input-field-input::placeholder,
+[class*='ag-theme-']
+  input.ag-input-field-input.ag-text-field-input::placeholder {
+  color: var(--picker-fg) !important;
+  opacity: 0.6; /* make it lighter but still visible */
+}
+
+/* WebKit autofill can force white text; pin it */
+[class*='ag-theme-'] .ag-input-field-input:-webkit-autofill {
+  -webkit-text-fill-color: var(--picker-fg) !important;
+  caret-color: var(--picker-fg) !important;
+  /* Optional: keep background normal instead of yellow */
+  box-shadow: 0 0 0px 1000px transparent inset !important;
+}
+
+/* Some AG states dim inputs via opacity—undo if needed */
+[class*='ag-theme-'] .ag-input-field-input.ag-disabled,
+[class*='ag-theme-'] .ag-input-field-input[disabled] {
+  opacity: 1 !important;
+}
+
+/* HARD LIGHT OVERRIDE (handles stray dark classes elsewhere) */
+html:not(.dark) [class*='ag-theme-'] .ag-input-field-input,
+html:not(.dark)
+  [class*='ag-theme-']
+  input.ag-input-field-input.ag-text-field-input {
+  color: #222 !important;
+  -webkit-text-fill-color: #222 !important; /* beats autofill */
 }
 
 .statistics-page {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

Made changes to 'Sttatistics.css' to ensure the text is visible in both dark mode and light mode
Had to specify elements due to issue with changing between light/dark mode

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [ ] No
Please write a brief description of why test coverage is not necessary here.
- [x] Not as part of this ticket. (Could be done at a later point)

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [ ] Yes
- [ ] No
Please write a brief description of why documentation is not necessary here.
- [x] Not as part of this ticket. (Could be done at a later point)

### Related issues

KEH-1310

### How to review

Check if it looks okay and the code is optimal
