### PR TITLE
KEH-1314-PATCH - Fix CSS on HelpModal

### DIFF
--- a/frontend/src/styles/components/HelpModal.css
+++ b/frontend/src/styles/components/HelpModal.css
@@ -1,11 +1,7 @@
 .help-modal-overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  right: unset;
-  bottom: unset;
+  right: 24px;
+  bottom: 0;
   display: flex;
   align-items: flex-end;
   justify-content: flex-end;

--- a/frontend/src/styles/components/HelpModal.css
+++ b/frontend/src/styles/components/HelpModal.css
@@ -7,14 +7,13 @@
   right: unset;
   bottom: unset;
   display: flex;
-  align-items: center;
-  justify-content: center;
+  align-items: flex-end;
+  justify-content: flex-end;
   z-index: 1000;
   box-sizing: border-box;
   pointer-events: none;
   opacity: 0;
   transition: opacity 1s cubic-bezier(0.16, 1, 0.3, 1);
-  background: rgba(0, 0, 0, 0.7);
 }
 
 .help-modal-overlay.show {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimisation
- [ ] Documentation Update

### What

There was a minor CSS change in branch KEH-1314 that made the HelpModal look like the images below.

I have removed the background as it didn't comply with the light/dark mode. Making the two CSS to flex-end fixed the errors where it placed it in the center.

Although Modals are considered to typically be in the center of a screen I wanted it to be in the bottom right where we have some free space and it would allow desktop users to have help there alongside them whilst they explore the app instead of opening/closing the modal.


<img width="1862" height="2016" alt="image" src="https://github.com/user-attachments/assets/189f220c-e430-4f9b-b841-8f41ba435eb1" style="hey"/>

Now it looks like this:

<img width="1862" height="2016" alt="image" src="https://github.com/user-attachments/assets/759e753e-e8d3-4c46-80f5-8e756a3080c3" />

### How to review

- make dev
- open Help from sidebar
- view fix
