### PR TITLE
KEH-1311 Fix Team Exit Handling

### DIFF
--- a/frontend/src/pages/CopilotPage.js
+++ b/frontend/src/pages/CopilotPage.js
@@ -61,10 +61,15 @@ function CopilotDashboard() {
     return diffDays;
   };
 
+  // Cancellation ref for fetchTeamData
+  const fetchTeamDataCancelRef = React.useRef({ cancelled: false });
+
   const fetchTeamData = async slug => {
+    fetchTeamDataCancelRef.current.cancelled = false;
     setIsTeamLoading(true);
 
     const liveUsage = await fetchTeamLiveUsageData(slug);
+    if (fetchTeamDataCancelRef.current.cancelled) return;
     if (!liveUsage) {
       toast.error('You do not have permission to view this team');
       setTeamSlug(null);
@@ -77,6 +82,7 @@ function CopilotDashboard() {
     setEndDate(end);
     setSliderValues([1, getEndSliderValue(liveUsage)]);
     const teamSeats = await fetchTeamSeatData(slug);
+    if (fetchTeamDataCancelRef.current.cancelled) return;
     const activeTeamSeats = filterInactiveUsers(teamSeats, startDate);
 
     setLiveTeamData({
@@ -492,15 +498,17 @@ function CopilotDashboard() {
 
                   <button
                     className="view-data-button"
-                    onClick={() => {
-                      setIsSelectingTeam(true);
-                      setTeamSlug(null);
-                      navigate('/copilot/team', { replace: true });
-                      const { start, end } = initialiseDateRange(data.allUsage);
-                      setStartDate(start);
-                      setEndDate(end);
-                      setSliderValues([1, getEndSliderValue(data.allUsage)]);
-                    }}
+                      onClick={() => {
+                        // Cancel any in-flight fetchTeamData
+                        fetchTeamDataCancelRef.current.cancelled = true;
+                        setIsSelectingTeam(true);
+                        setTeamSlug(null);
+                        navigate('/copilot/team', { replace: true });
+                        const { start, end } = initialiseDateRange(data.allUsage);
+                        setStartDate(start);
+                        setEndDate(end);
+                        setSliderValues([1, getEndSliderValue(data.allUsage)]);
+                      }}
                     aria-label={`Return to team selection`}
                   >
                     <FaArrowLeft size={10} />


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

Added a 'fetchTeamDataCancelRef' to the 'CopilpotPage.js' so if the data is not loaded and the user returns to the teams page it will not continue to load the data.

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [ ] No
Please write a brief description of why test coverage is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [ ] Yes
- [ ] No
Please write a brief description of why documentation is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Related issues

KEH-1311

### How to review

Check if the bug does not occur.
