### PR TITLE
KEH-1485 - Change 'Copilot' to 'GitHub Copilot'

### DIFF
--- a/frontend/src/components/MenuDropdown/MenuDropdown.js
+++ b/frontend/src/components/MenuDropdown/MenuDropdown.js
@@ -101,7 +101,7 @@ function MenuDropdown({ setShowHelpModal }) {
               className={location.pathname === '/copilot' ? 'active' : ''}
             >
               <VscCopilot size={16} />
-              Copilot
+              GitHub Copilot
             </button>
           </div>
 

--- a/frontend/src/components/Sidebar/Sidebar.js
+++ b/frontend/src/components/Sidebar/Sidebar.js
@@ -49,7 +49,7 @@ const Sidebar = () => {
     { path: '/projects', label: 'Projects', icon: <TbUsers />, isLink: true },
     {
       path: '/copilot',
-      label: 'Copilot',
+      label: 'GitHub Copilot',
       icon: <VscCopilot />,
       isLink: true,
       hasChildren: true,

--- a/frontend/src/pages/HomePage.js
+++ b/frontend/src/pages/HomePage.js
@@ -100,7 +100,8 @@ function HomePage() {
                 <h2>GitHub Copilot</h2>
               </div>
               <p>
-                Analyse GitHub Copilot usage statistics organisation-wide and by team.
+                Analyse GitHub Copilot usage statistics organisation-wide and by
+                team.
               </p>
             </a>
           </div>

--- a/frontend/src/pages/HomePage.js
+++ b/frontend/src/pages/HomePage.js
@@ -97,10 +97,10 @@ function HomePage() {
             <a className="nav-card" href="/copilot">
               <div className="nav-card-header">
                 <VscCopilot />
-                <h2>Copilot</h2>
+                <h2>GitHub Copilot</h2>
               </div>
               <p>
-                Analyse Copilot usage statistics organisation-wide and by team.
+                Analyse GitHub Copilot usage statistics organisation-wide and by team.
               </p>
             </a>
           </div>

--- a/mkdocs/docs/pages/copilot/index.md
+++ b/mkdocs/docs/pages/copilot/index.md
@@ -1,4 +1,4 @@
-# Copilot Usage Dashboard
+# GitHub Copilot Usage Dashboard
 
 The Copilot dashboard allows users to analyse GitHub Copilot usage statistics across the organisation and within individual teams.
 

--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -10,7 +10,7 @@ nav:
       - Statistics: pages/statistics/index.md
       - Review: pages/review/index.md
       - Admin: pages/admin/index.md
-      - Copilot: pages/copilot/index.md
+      - GitHub Copilot: pages/copilot/index.md
   - Backend:
       - Overview: backend/index.md
       - Services:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Documentation Update

### What

Some viewers mentioned that Copilot is commonly associated with Microsoft copilot within the organisation. This PR changes mentions of Copilot to GitHub Copilot. The code still remains the same, for instance, the url still says Copilot, but what the base user sees mentions GitHub Copilot.

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [x] Yes

### How to review

- View desktop and mobile to test sidebar and dropdown.
- Look at MkDocs to see GitHub Copilot instead of Copilot.
