### PR TITLE
KEH-1505 - Highlight Directorate Specific Blips

### DIFF
--- a/frontend/src/pages/RadarPage.js
+++ b/frontend/src/pages/RadarPage.js
@@ -1228,6 +1228,15 @@ function RadarPage() {
                               r="15"
                               className={`blip ${ring.toLowerCase()}`}
                             />
+                            {getShouldBeHighlighted(entry.timeline) && (
+                              <circle
+                                r="15"
+                                className="blip-highlight"
+                                stroke={directorateColour}
+                                strokeWidth="2"
+                                fill="none"
+                              />
+                            )}
                             {isSelected && (
                               <circle
                                 r="18"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

On the Tech Radar, technology blips with a directorate specific position are now highlighted.

<img width="2277" height="1046" alt="Screenshot 2025-10-07 at 13 24 23" src="https://github.com/user-attachments/assets/e8925084-06dd-4fb4-a0b4-03c53362869d" />

(Data removed from screenshot)

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [x] No
Please write a brief description of why test coverage is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [ ] Yes
- [x] No
Please write a brief description of why documentation is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Related issues

KEH-1505 (Jira)

### How to review

Run the tool locally and switch between directorates. Any technologies with a directorate specific position will be highlighted.