### PR TITLE
KEH-1561 - Fix bug-modal-content

### DIFF
--- a/frontend/src/components/BugReport/Modal.js
+++ b/frontend/src/components/BugReport/Modal.js
@@ -13,7 +13,7 @@ const Modal = ({ isOpen, onClose }) => {
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal-content" onClick={e => e.stopPropagation()}>
+      <div className="bug-modal-content" onClick={e => e.stopPropagation()}>
         <div className="modal-header">
           <h2>Report a Bug</h2>
           <button className="modal-close-button" onClick={onClose}>

--- a/frontend/src/styles/components/BugReport.css
+++ b/frontend/src/styles/components/BugReport.css
@@ -38,7 +38,7 @@
   z-index: 1001 !important;
 }
 
-.modal-content {
+.bug-modal-content {
   background: hsl(var(--background));
   padding: 20px;
   border-radius: var(--radius);
@@ -80,7 +80,7 @@
   font-size: 20px;
 }
 
-.modal-content p {
+.bug-modal-content p {
   color: hsl(var(--foreground));
   margin: 0;
   margin-bottom: 10px;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

<img width="1148" height="962" alt="image" src="https://github.com/user-attachments/assets/6f65d200-c77f-4ec4-8cc8-46e188565d65" />

Modal content was shrunk to max 500px due to clash in class names.

### Related issues

Bug implemented in KEH-1367.
