### PR TITLE
KEH-1448 - TechRadar Bugfix

### DIFF
--- a/frontend/src/pages/RadarPage.js
+++ b/frontend/src/pages/RadarPage.js
@@ -1394,11 +1394,7 @@ function RadarPage() {
                 </span>
               </div>
             </div>
-            <ul 
-              tabIndex="0"
-              role="list"
-              aria-label="Frameworks technologies"
-            >
+            <ul tabIndex="0" role="list" aria-label="Frameworks technologies">
               {numberedEntries['2']?.map(entry => (
                 <li
                   key={entry.id}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

Added the Framework and Technologies to the 'quadrant-lists' on 'RadarPage.js' so now when the user holds TAB it will cycle through that as well

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [x] No
No major change or new feature has been added
- [ ] Not as part of this ticket. (Could be done at a later point)

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [ ] Yes
- [x] No
No major change or new feature has been added
- [ ] Not as part of this ticket. (Could be done at a later point)

### Related issues

KEH-1448

### How to review

Open the app and on the Radarpage hold tab and check if it cycles through all the lists.
