### PR TITLE
KEH-Fix MkDocs Error

### DIFF
--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -120,7 +120,7 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
-          paths: '..'
+          paths: ['..']
 
 extra_css:
   - stylesheets/extra.css

--- a/mkdocs/mkdocs_requirements.txt
+++ b/mkdocs/mkdocs_requirements.txt
@@ -1,7 +1,5 @@
 mkdocs==1.6.1
-mkdocs-material==9.5.34
-mkdocstrings==0.25.2
-mkdocstrings-python==1.10.5
-griffe==0.36.7
-mkdocs-git-revision-date-localized-plugin==1.2.4
-mkdocs-autorefs==1.0.1
+mkdocs-material==9.7.0
+mkdocstrings-python==2.0.0
+pymdown-extensions==10.17.2
+mkdocs-material-extensions==1.3.1


### PR DESCRIPTION
…re mismatch. added compatible pairs

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

Changed the requirements version to match 
mkdocstrings_handlers.python requiring mkdocstrings.extension, which exists in mkdocstrings<0.24.

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [ ] No
Please write a brief description of why test coverage is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [ ] Yes
- [ ] No
Please write a brief description of why documentation is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Related issues

Provide links to any related issues.

### How to review

Check if the solution works and makes sense
