### PR TITLE
KEH-1518 - Minor Reviewer State Changing Errors

### DIFF
--- a/frontend/src/pages/ReviewPage.js
+++ b/frontend/src/pages/ReviewPage.js
@@ -71,6 +71,7 @@ const ReviewPage = () => {
 
   const [highlightedTechnologies, setHighlightedTechnologies] = useState([]);
   const [changedTechnologies, setChangedTechnologies] = useState([]);
+  const [editedItem, setEditedItem] = useState(null);
 
   const [stashedDefaultTimeline, setStashedDefaultTimeline] = useState({});
 
@@ -644,6 +645,42 @@ const ReviewPage = () => {
     setShowConfirmModal(false);
     setEditedTitle('');
     setEditedCategory('');
+    setEditedItem(null);
+
+    // Track the edit as a change so Save button becomes enabled
+    const existingChangeIndex = changedTechnologies.findIndex(
+      change =>
+        change.technology === selectedItem.title ||
+        change.technology === editedTitle
+    );
+    if (existingChangeIndex === -1) {
+      setChangedTechnologies(prev => [
+        ...prev,
+        {
+          technology: editedTitle,
+          edited: true,
+          from: selectedItem.title,
+          category: editedCategory,
+          directorate: selectedDirectorate,
+        },
+      ]);
+    } else {
+      // Update existing change entry
+      setChangedTechnologies(prev =>
+        prev.map((change, index) =>
+          index === existingChangeIndex
+            ? {
+                ...change,
+                technology: editedTitle,
+                edited: true,
+                category: editedCategory,
+                directorate: selectedDirectorate,
+              }
+            : change
+        )
+      );
+    }
+
     toast.success('Technology updated successfully');
   };
 
@@ -1260,11 +1297,21 @@ const ReviewPage = () => {
               <ul className="change-list">
                 {changedTechnologies.map((change, index) => (
                   <li key={index}>
-                    {change.from === undefined && change.to === undefined ? (
+                    {change.from === undefined &&
+                    change.to === undefined &&
+                    !change.edited ? (
                       <>
                         {change.technology} (
                         <span style={{ color: 'green', fontWeight: 'bold' }}>
                           New
+                        </span>
+                        )
+                      </>
+                    ) : change.edited && change.to === undefined ? (
+                      <>
+                        {change.from} &rarr; {change.technology} (
+                        <span style={{ color: 'blue', fontWeight: 'bold' }}>
+                          Edited
                         </span>
                         )
                       </>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

Ticket:

As a reviewer I want to be able to save changes when I make changes to a tech quadrant so that I can reflect the most up-to-date information. 

- Acceptance criteria
- Able to save changes when changing a tech quadrant.
- Revert changes is also clickable and actually reverts the changes on a tech.

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [x] No
Please write a brief description of why test coverage is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [ ] Yes
- [x] No
Please write a brief description of why documentation is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### How to review

- make dev
- /review/dashboard
- change Python to Pythons **but don't move it's quadrant**
- click tick button
- save changes
- view the difference
- happy days
