### PR TITLE
fix: remove old link to documentation

### DIFF
--- a/frontend/src/components/Header/HelpModal.js
+++ b/frontend/src/components/Header/HelpModal.js
@@ -49,7 +49,7 @@ function HelpModal({ show, onClose }) {
           To view more detailed information about the Digital Landscape, view
           this{' '}
           <a
-            href="https://ons-innovation.github.io/keh-digital-landscape/"
+            href="https://onsdigital.github.io/keh-digital-landscape/"
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

Changed the link for documentation to new ONSDigital link

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [x] No
Please write a brief description of why test coverage is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [ ] Yes
- [x] No
Please write a brief description of why documentation is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Related issues

N/A

### How to review

`make dev`, navigate to homepage, click help on the side-bar, then click the link to the documentation ("To view more detailed information about the Digital Landscape, view this [documentation](https://onsdigital.github.io/keh-digital-landscape/).")