### PR TITLE
KEH-1706: AWS Key Rotation

### DIFF
--- a/terraform/service/iam.tf
+++ b/terraform/service/iam.tf
@@ -164,10 +164,6 @@ resource "aws_iam_group_policy_attachment" "group_secretsmanager_access_attach" 
 resource "aws_iam_user" "user" {
   name = "${var.domain}-${var.service_subdomain}"
   path = "/"
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 # Assign IAM User to group
@@ -180,16 +176,12 @@ resource "aws_iam_user_group_membership" "user_group_attach" {
 }
 
 # IAM Key Rotation Module
-#
-# This module was originally provisioned by Terraform, but is no longer managed by it. 
-# It remains here commented out, ensuring the overall AWS infrastructure for this service
-# is captured fully. See AWS Key Rotation documentation on Confluence for further details.
-#
-# module "iam_key_rotation" {
-#   source = "git::https://github.com/ONSdigital/aws-iam-key-rotation.git"
-#
-#   iam_username          = aws_iam_user.user.name
-#   access_key_secret_arn = aws_secretsmanager_secret.access_key.arn
-#   secret_key_secret_arn = aws_secretsmanager_secret.secret_key.arn
-#   rotation_in_days      = 90
-# }
+
+module "iam_key_rotation" {
+  source = "git::https://github.com/ONSdigital/aws-iam-key-rotation.git"
+
+  iam_username          = aws_iam_user.user.name
+  access_key_secret_arn = aws_secretsmanager_secret.access_key.arn
+  secret_key_secret_arn = aws_secretsmanager_secret.secret_key.arn
+  rotation_in_days      = 90
+}

--- a/terraform/service/secrets.tf
+++ b/terraform/service/secrets.tf
@@ -2,17 +2,9 @@
 resource "aws_secretsmanager_secret" "access_key" {
   name        = "${var.domain}-${var.service_subdomain}-digital-landscape-access-key"
   description = "Access Key ID for digital landscape IAM user"
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "aws_secretsmanager_secret" "secret_key" {
   name        = "${var.domain}-${var.service_subdomain}-digital-landscape-secret-key"
   description = "Secret Access Key for digital landscape IAM user"
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

Further to the changes made in KEH-1706 (Credential Refactor), the keys associated with the IAM user now undergo rotation in line with best practice, every 90 days.

Check out: https://github.com/ONSdigital/aws-iam-key-rotation

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [x] No
Please write a brief description of why test coverage is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [ ] Yes
- [ ] No
Please write a brief description of why documentation is not necessary here.
- [x] Not as part of this ticket. (Could be done at a later point)

### Related issues

N/A

### How to review

Login to sdp-dev on AWS. There should be the following:

- Access and Secret Keys stored in Secrets Manager
- Lambda function setup (as .zip)
- EventBridge Scheduler (will trigger the lambda every 90 days)
- CloudWatch log group setup

You can manually trigger the lambda in the CLI using:

```
aws lambda invoke \
  --function-name iam-key-rotation-sdp-dev-digital-landscape \
  --region eu-west-2 \
  response.json
```

Then run `cat response.json` to confirm the status of the invocation. If it returns 200 then the operation is successful. You will also see the access and secret key change :)