### PR TITLE
KEH-1983 - fix 5xx alarms

### DIFF
--- a/terraform/service/main.tf
+++ b/terraform/service/main.tf
@@ -271,7 +271,7 @@ resource "aws_cloudwatch_metric_alarm" "application_elb_5xx_alarm" {
   alarm_description         = "Alarm when Application ELB produces 5xx Errors"
   insufficient_data_actions = []
   treat_missing_data        = "notBreaching"
-  dimensions                = { LoadBalancer = "${var.domain}-service-lb" }
+  dimensions                = { LoadBalancer = data.terraform_remote_state.ecs_infrastructure.outputs.application_lb_arn_suffix }
 }
 
 

--- a/terraform/service/main.tf
+++ b/terraform/service/main.tf
@@ -271,7 +271,7 @@ resource "aws_cloudwatch_metric_alarm" "application_elb_5xx_alarm" {
   alarm_description         = "Alarm when Application ELB produces 5xx Errors"
   insufficient_data_actions = []
   treat_missing_data        = "notBreaching"
-  dimensions                = { LoadBalancer = data.terraform_remote_state.ecs_infrastructure.outputs.application_lb_arn_suffix }
+  dimensions                = { LoadBalancer = data.terraform_remote_state.ecs_infrastructure.outputs.application_lb_arn }
 }
 
 


### PR DESCRIPTION
Attempts to fix alarm on AWS for 5xx errors. Alarm was simply pointing to the wrong thing.