### PR TITLE
Fix Statistics page scrolling and update accordion expand indicator

### DIFF
--- a/frontend/src/components/Statistics/Statistics.js
+++ b/frontend/src/components/Statistics/Statistics.js
@@ -8,7 +8,7 @@ import { useTechnologyStatus } from '../../utilities/getTechnologyStatus';
 import { specialTechMatchers } from '../../utilities/getSpecialTechMatchers';
 import { formatNumberWithCommas } from '../../utilities/getCommaSeparated';
 import * as Accordion from '@radix-ui/react-accordion';
-import { IoHelpCircleSharp } from 'react-icons/io5';
+import { IoChevronDown, IoHelpCircleSharp } from 'react-icons/io5';
 
 /**
  * Statistics component for displaying repository statistics.
@@ -573,6 +573,9 @@ function Statistics({
                     />{' '}
                     What do the colours mean?
                   </h3>
+                  <span className="stats-accordion-icon" aria-hidden="true">
+                    <IoChevronDown />
+                  </span>
                 </Accordion.Trigger>
                 <Accordion.Content
                   id="colour-help-content"

--- a/frontend/src/styles/components/Statistics.css
+++ b/frontend/src/styles/components/Statistics.css
@@ -15,7 +15,7 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .statistics-header {
@@ -82,8 +82,8 @@
   flex-direction: column;
   gap: 16px;
   height: 100%;
-  min-height: 0;
-  overflow: hidden;
+  min-height: auto;
+  overflow: visible;
 }
 
 .language-header {
@@ -473,22 +473,11 @@
   transform: translateY(2px);
 }
 
-.stats-accordion-trigger:after {
-  content: '[Expand]';
+.stats-accordion-icon {
   margin-left: auto;
   transition: transform 0.2s ease;
 }
 
-.stats-accordion-trigger[aria-expanded='true']:after {
-  content: '[Collapse]';
-}
-
-.stats-accordion-content {
-  margin-top: 0.5em;
-  padding: 0 16px 16px 16px;
-  border: 1px solid hsl(var(--border));
-  border-radius: var(--radius);
-  background: hsl(var(--card));
-  color: hsl(var(--card-foreground));
-  text-align: center;
+.stats-accordion-trigger[data-state='open'] .stats-accordion-icon {
+  transform: rotate(180deg);
 }


### PR DESCRIPTION
## Overview

This PR addreses issue on the Statistics page where the main page content was not scrollable. As a result, on smaller screens it was difficult for users to reach and use the scrollable language list section. It also replaces the accordion’s text-based expand/collapse label with a chevron icon.

What changed:

- Enabled scrolling for the main Statistics page content.
- Replaced the accordion [Expand] / [Collapse] text with a chevron icon and open-state rotation.

## Related Issues

<!-- List any related issues or pull requests here -->
<!-- This can include issues from Jira but make sure *not* to link them -->
KEH-2203

## Testing

<!-- Describe how to test the changes in this pull request -->

- Verify that no CSS or component errors after the changes
- Confirm that the main page content can scroll.
- Confirm that he accordion icon updates correctly when opened.

## Checklist

<!-- Please check off the following items before submitting this pull request -->
<!-- If anything is not applicable, please explain why in the exemptions section -->

- [x] I have reviewed the changes in this pull request
- [x] I have tested the changes locally
- [ ] I have updated/created any relevant documentation
- [ ] I have updated/created any relevant tests
- [x] All CI checks have passed
- [ ] I have used a development Concourse pipeline to test the changes within a development environment
- [x] I have added any necessary labels to this pull request
- [x] I have assigned myself to this pull request
- [x] I have assigned the appropriate reviewers to this pull request

### Exemptions

<!-- If any of the above checklist items are not applicable, please explain why here -->

## Additional Notes

<!-- Add any additional notes or comments here -->
