### PR TITLE
[KEH-2183] Use description instead of message for banner description

### DIFF
--- a/backend/src/routes/admin.banner.test.js
+++ b/backend/src/routes/admin.banner.test.js
@@ -60,7 +60,7 @@ describe('Admin banner routes', () => {
       const res = await fetch(`${baseUrl}/admin/api/banners/update`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ banner: { message: '', pages: [] } }),
+        body: JSON.stringify({ banner: { description: '', pages: [] } }),
       });
 
       expect(res.status).toBe(400);
@@ -78,7 +78,7 @@ describe('Admin banner routes', () => {
       const payload = {
         banner: {
           title: 'Planned downtime',
-          message: 'Service unavailable tonight',
+          description: 'Service unavailable tonight',
           type: 'warning',
           pages: ['/projects'],
         },
@@ -99,7 +99,6 @@ describe('Admin banner routes', () => {
         messages: [
           {
             title: 'Planned downtime',
-            message: 'Service unavailable tonight',
             description: 'Service unavailable tonight',
             type: 'warning',
             pages: ['/projects'],
@@ -113,14 +112,14 @@ describe('Admin banner routes', () => {
   describe('GET /admin/api/banners', () => {
     it('returns all messages when messages.json exists', async () => {
       vi.spyOn(s3Service, 'getObject').mockResolvedValue({
-        messages: [{ message: 'Banner one', pages: ['/'] }],
+        messages: [{ description: 'Banner one', pages: ['/'] }],
       });
 
       const res = await fetch(`${baseUrl}/admin/api/banners`);
 
       expect(res.status).toBe(200);
       await expect(res.json()).resolves.toEqual({
-        messages: [{ message: 'Banner one', pages: ['/'] }],
+        messages: [{ description: 'Banner one', pages: ['/'] }],
       });
     });
 
@@ -184,7 +183,7 @@ describe('Admin banner routes', () => {
 
     it('updates banner visibility and persists messages', async () => {
       const messages = {
-        messages: [{ message: 'Notice', show: true, pages: ['/'] }],
+        messages: [{ description: 'Notice', show: true, pages: ['/'] }],
       };
       vi.spyOn(s3Service, 'getObject').mockResolvedValue(messages);
       const putObjectSpy = vi.spyOn(s3Service, 'putObject').mockResolvedValue();
@@ -200,7 +199,7 @@ describe('Admin banner routes', () => {
         message: 'Banner visibility updated successfully',
       });
       expect(putObjectSpy).toHaveBeenCalledWith('main', 'messages.json', {
-        messages: [{ message: 'Notice', show: false, pages: ['/'] }],
+        messages: [{ description: 'Notice', show: false, pages: ['/'] }],
       });
     });
   });
@@ -237,8 +236,8 @@ describe('Admin banner routes', () => {
     it('deletes a banner and persists messages', async () => {
       const messages = {
         messages: [
-          { message: 'Keep me', show: true, pages: ['/'] },
-          { message: 'Delete me', show: true, pages: ['/projects'] },
+          { description: 'Keep me', show: true, pages: ['/'] },
+          { description: 'Delete me', show: true, pages: ['/projects'] },
         ],
       };
       vi.spyOn(s3Service, 'getObject').mockResolvedValue(messages);
@@ -255,7 +254,7 @@ describe('Admin banner routes', () => {
         message: 'Banner deleted successfully',
       });
       expect(putObjectSpy).toHaveBeenCalledWith('main', 'messages.json', {
-        messages: [{ message: 'Keep me', show: true, pages: ['/'] }],
+        messages: [{ description: 'Keep me', show: true, pages: ['/'] }],
       });
     });
   });

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -76,7 +76,7 @@ router.post('/banners/update', async (req, res) => {
     // Add the new banner to messages
     messagesData.messages.push({
       title: banner.title || '',
-      description: banner.description, // For backwards compatibility
+      description: banner.description,
       type: banner.type || 'info',
       pages: banner.pages,
       show: banner.show !== false, // Default to true if not explicitly set to false

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -55,7 +55,7 @@ router.post('/banners/update', async (req, res) => {
     // Validate banner data
     if (
       !banner ||
-      !banner.message ||
+      !banner.description ||
       !Array.isArray(banner.pages) ||
       banner.pages.length === 0
     ) {
@@ -76,8 +76,7 @@ router.post('/banners/update', async (req, res) => {
     // Add the new banner to messages
     messagesData.messages.push({
       title: banner.title || '',
-      message: banner.message,
-      description: banner.message, // For backwards compatibility
+      description: banner.description, // For backwards compatibility
       type: banner.type || 'info',
       pages: banner.pages,
       show: banner.show !== false, // Default to true if not explicitly set to false

--- a/docs/functionality/bannerSupport.md
+++ b/docs/functionality/bannerSupport.md
@@ -55,7 +55,6 @@ All banners are stored in AWS S3 as a JSON file (`messages.json`). Each banner i
   "messages": [
     {
       "title": "Test Banner",
-      "message": "Test Banner Message",
       "description": "Test Banner Message",
       "type": "info", // Either info, warning, or error
       "pages": [

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5099,7 +5099,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",

--- a/frontend/src/utilities/getBanner.js
+++ b/frontend/src/utilities/getBanner.js
@@ -40,8 +40,8 @@ export const fetchBanners = async page => {
         return false;
       })
       .map(message => ({
-        title: message.title || message.message || '',
-        description: message.description || message.message || '',
+        title: message.title || message.description || '',
+        description: message.description || '',
         type: message.type || 'info',
       }))
       .filter(banner => {


### PR DESCRIPTION
Fixes the duplication issue with message and description for banners. This change enforces the use of description only. 