### PR TITLE
fix: update IAM key rotation period from 90 to 45 days

### DIFF
--- a/terraform/service/iam.tf
+++ b/terraform/service/iam.tf
@@ -183,5 +183,5 @@ module "iam_key_rotation" {
   iam_username          = aws_iam_user.user.name
   access_key_secret_arn = aws_secretsmanager_secret.access_key.arn
   secret_key_secret_arn = aws_secretsmanager_secret.secret_key.arn
-  rotation_in_days      = 90
+  rotation_in_days      = 45
 }


### PR DESCRIPTION
## Overview

Update to meet Security Hub control:

This control checks whether your IAM users have passwords or active access keys that were not used within the previous 45 days.

## Related Issues

<!-- List any related issues or pull requests here -->
<!-- This can include issues from Jira but make sure *not* to link them -->

## Testing

<!-- Describe how to test the changes in this pull request -->

## Checklist

<!-- Please check off the following items before submitting this pull request -->
<!-- If anything is not applicable, please explain why in the exemptions section -->

- [ ] I have reviewed the changes in this pull request
- [ ] I have tested the changes locally
- [ ] I have updated/created any relevant documentation
- [ ] I have updated/created any relevant tests
- [ ] All CI checks have passed
- [ ] I have used a development Concourse pipeline to test the changes within a development environment
- [ ] I have added any necessary labels to this pull request
- [ ] I have assigned myself to this pull request
- [ ] I have assigned the appropriate reviewers to this pull request

### Exemptions

<!-- If any of the above checklist items are not applicable, please explain why here -->

## Additional Notes

<!-- Add any additional notes or comments here -->
