### PR TITLE
feat: add EBS encryption by default for sdp_account

### DIFF
--- a/terraform/account/ebs.tf
+++ b/terraform/account/ebs.tf
@@ -1,0 +1,3 @@
+resource "aws_ebs_encryption_by_default" "sdp_account" {
+  enabled = true
+}


### PR DESCRIPTION
## Overview

Enable EBS encryption by default to acc

> Checks if Amazon Elastic Block Store (EBS) encryption is enabled by default. The rule is NON_COMPLIANT if the encryption is not enabled.

## Related Issues
n/a

## Testing
n/a

## Checklist

<!-- Please check off the following items before submitting this pull request -->
<!-- If anything is not applicable, please explain why in the exemptions section -->

- [ ] I have reviewed the changes in this pull request
- [ ] I have tested the changes locally
- [ ] I have updated/created any relevant documentation
- [ ] I have updated/created any relevant tests
- [ ] All CI checks have passed
- [ ] I have used a development Concourse pipeline to test the changes within a development environment
- [ ] I have added any necessary labels to this pull request
- [ ] I have assigned myself to this pull request
- [ ] I have assigned the appropriate reviewers to this pull request

### Exemptions

<!-- If any of the above checklist items are not applicable, please explain why here -->

## Additional Notes

<!-- Add any additional notes or comments here -->
