### PR TITLE
KEH-2182 - Refactor banner type input to use radios

### DIFF
--- a/frontend/src/components/Admin/BannerManage.js
+++ b/frontend/src/components/Admin/BannerManage.js
@@ -168,30 +168,51 @@ const BannerManage = () => {
           <div className="admin-modal-field">
             <label>Type</label>
             <div className="banner-type-selector">
-              <div
+              <label
                 id="info-type-option"
                 className={`banner-type-option ${bannerType === 'info' ? 'selected' : ''}`}
-                onClick={() => setBannerType('info')}
               >
+                <input
+                  type="radio"
+                  name="bannerType"
+                  value="info"
+                  checked={bannerType === 'info'}
+                  onChange={() => setBannerType('info')}
+                  aria-label="Info banner type"
+                />
                 <span className="banner-type-indicator info" />
                 Info
-              </div>
-              <div
+              </label>
+              <label
                 id="warning-type-option"
                 className={`banner-type-option ${bannerType === 'warning' ? 'selected' : ''}`}
-                onClick={() => setBannerType('warning')}
               >
+                <input
+                  type="radio"
+                  name="bannerType"
+                  value="warning"
+                  checked={bannerType === 'warning'}
+                  onChange={() => setBannerType('warning')}
+                  aria-label="Warning banner type"
+                />
                 <span className="banner-type-indicator warning" />
                 Warning
-              </div>
-              <div
+              </label>
+              <label
                 id="error-type-option"
                 className={`banner-type-option ${bannerType === 'error' ? 'selected' : ''}`}
-                onClick={() => setBannerType('error')}
               >
+                <input
+                  type="radio"
+                  name="bannerType"
+                  value="error"
+                  checked={bannerType === 'error'}
+                  onChange={() => setBannerType('error')}
+                  aria-label="Error banner type"
+                />
                 <span className="banner-type-indicator error" />
                 Error
-              </div>
+              </label>
             </div>
           </div>
 

--- a/frontend/src/styles/ReviewPage.css
+++ b/frontend/src/styles/ReviewPage.css
@@ -1001,6 +1001,14 @@ textarea.technology-input {
   transition: all 0.2s ease;
 }
 
+.banner-type-option input[type='radio'] {
+  margin: 0;
+  width: 0;
+  height: 0;
+  visibility: hidden;
+  position: absolute;
+}
+
 .banner-type-option:hover {
   background: hsl(var(--accent));
 }

--- a/testing/ui/tests/admin.banners.test.js
+++ b/testing/ui/tests/admin.banners.test.js
@@ -270,12 +270,22 @@ test.describe('add banner', () => {
 
 test.describe('banner type selector', () => {
   test('info type should be selected by default', async ({ page }) => {
-    await expect(page.locator('input[aria-label="Info banner type"]')).toBeChecked();
-    await expect(page.locator('input[aria-label="Warning banner type"]')).not.toBeChecked();
-    await expect(page.locator('input[aria-label="Error banner type"]')).not.toBeChecked();
+    await expect(
+      page.locator('input[aria-label="Info banner type"]')
+    ).toBeChecked();
+    await expect(
+      page.locator('input[aria-label="Warning banner type"]')
+    ).not.toBeChecked();
+    await expect(
+      page.locator('input[aria-label="Error banner type"]')
+    ).not.toBeChecked();
     await expect(page.locator('#info-type-option')).toHaveClass(/selected/);
-    await expect(page.locator('#warning-type-option')).not.toHaveClass(/selected/);
-    await expect(page.locator('#error-type-option')).not.toHaveClass(/selected/);
+    await expect(page.locator('#warning-type-option')).not.toHaveClass(
+      /selected/
+    );
+    await expect(page.locator('#error-type-option')).not.toHaveClass(
+      /selected/
+    );
   });
 
   const bannerTypes = [
@@ -290,12 +300,23 @@ test.describe('banner type selector', () => {
     }) => {
       await page.locator(`#${type}-type-option`).click();
 
-      await expect(page.locator(`input[aria-label="${ariaLabel}"]`)).toBeChecked();
-      await expect(page.locator(`#${type}-type-option`)).toHaveClass(/selected/);
+      await expect(
+        page.locator(`input[aria-label="${ariaLabel}"]`)
+      ).toBeChecked();
+      await expect(page.locator(`#${type}-type-option`)).toHaveClass(
+        /selected/
+      );
 
-      for (const { type: otherType, ariaLabel: otherAriaLabel } of bannerTypes.filter(t => t.type !== type)) {
-        await expect(page.locator(`input[aria-label="${otherAriaLabel}"]`)).not.toBeChecked();
-        await expect(page.locator(`#${otherType}-type-option`)).not.toHaveClass(/selected/);
+      for (const {
+        type: otherType,
+        ariaLabel: otherAriaLabel,
+      } of bannerTypes.filter(t => t.type !== type)) {
+        await expect(
+          page.locator(`input[aria-label="${otherAriaLabel}"]`)
+        ).not.toBeChecked();
+        await expect(page.locator(`#${otherType}-type-option`)).not.toHaveClass(
+          /selected/
+        );
       }
     });
   }

--- a/testing/ui/tests/admin.banners.test.js
+++ b/testing/ui/tests/admin.banners.test.js
@@ -268,6 +268,59 @@ test.describe('add banner', () => {
   });
 });
 
+test.describe('banner type selector', () => {
+  test('info type should be selected by default', async ({ page }) => {
+    await expect(page.locator('input[aria-label="Info banner type"]')).toBeChecked();
+    await expect(page.locator('input[aria-label="Warning banner type"]')).not.toBeChecked();
+    await expect(page.locator('input[aria-label="Error banner type"]')).not.toBeChecked();
+    await expect(page.locator('#info-type-option')).toHaveClass(/selected/);
+    await expect(page.locator('#warning-type-option')).not.toHaveClass(/selected/);
+    await expect(page.locator('#error-type-option')).not.toHaveClass(/selected/);
+  });
+
+  const bannerTypes = [
+    { type: 'info', ariaLabel: 'Info banner type' },
+    { type: 'warning', ariaLabel: 'Warning banner type' },
+    { type: 'error', ariaLabel: 'Error banner type' },
+  ];
+
+  for (const { type, ariaLabel } of bannerTypes) {
+    test(`clicking ${type} type should select it and deselect others`, async ({
+      page,
+    }) => {
+      await page.locator(`#${type}-type-option`).click();
+
+      await expect(page.locator(`input[aria-label="${ariaLabel}"]`)).toBeChecked();
+      await expect(page.locator(`#${type}-type-option`)).toHaveClass(/selected/);
+
+      for (const { type: otherType, ariaLabel: otherAriaLabel } of bannerTypes.filter(t => t.type !== type)) {
+        await expect(page.locator(`input[aria-label="${otherAriaLabel}"]`)).not.toBeChecked();
+        await expect(page.locator(`#${otherType}-type-option`)).not.toHaveClass(/selected/);
+      }
+    });
+  }
+
+  test('selecting a type should be reflected in the saved banner', async ({
+    page,
+  }) => {
+    const bannerData = {
+      title: 'Type Test Banner',
+      description: 'Testing banner type selection.',
+      type: 'warning',
+      pages: ['radar'],
+    };
+
+    await fillInBannerForm(page, bannerData);
+    await page.locator('#save-banner-button').click();
+    await page.locator('#confirm-banner-button').click();
+
+    const newBannerIndex = banners.messages.length - 1;
+    const bannerTypeLocator = page.locator(`#banner-type-${newBannerIndex}`);
+
+    await expect(bannerTypeLocator).toHaveText('warning');
+  });
+});
+
 test.describe('banner actions', () => {
   test('hide button should hide banner on specified pages', async ({
     page,


### PR DESCRIPTION
## Overview

Refactors inputs on the admin page to use radio types, which were previously just styled divs.

## Related Issues

KEH-2182

## Testing

Review the page and tests.

## Checklist

<!-- Please check off the following items before submitting this pull request -->
<!-- If anything is not applicable, please explain why in the exemptions section -->

- [x] I have reviewed the changes in this pull request
- [x] I have tested the changes locally
- [ ] I have updated/created any relevant documentation
- [ ] I have updated/created any relevant tests
- [ ] All CI checks have passed
- [ ] I have used a development Concourse pipeline to test the changes within a development environment
- [x] I have added any necessary labels to this pull request
- [x] I have assigned myself to this pull request
- [x] I have assigned the appropriate reviewers to this pull request

### Exemptions

<!-- If any of the above checklist items are not applicable, please explain why here -->
