### PR TITLE
KEH-2364: Fixed test failure by adjusting data loading order

### DIFF
--- a/frontend/src/components/Admin/BannerManage.js
+++ b/frontend/src/components/Admin/BannerManage.js
@@ -168,30 +168,51 @@ const BannerManage = () => {
           <div className="admin-modal-field">
             <label>Type</label>
             <div className="banner-type-selector">
-              <div
+              <label
                 id="info-type-option"
                 className={`banner-type-option ${bannerType === 'info' ? 'selected' : ''}`}
-                onClick={() => setBannerType('info')}
               >
+                <input
+                  type="radio"
+                  name="bannerType"
+                  value="info"
+                  checked={bannerType === 'info'}
+                  onChange={() => setBannerType('info')}
+                  aria-label="Info banner type"
+                />
                 <span className="banner-type-indicator info" />
                 Info
-              </div>
-              <div
+              </label>
+              <label
                 id="warning-type-option"
                 className={`banner-type-option ${bannerType === 'warning' ? 'selected' : ''}`}
-                onClick={() => setBannerType('warning')}
               >
+                <input
+                  type="radio"
+                  name="bannerType"
+                  value="warning"
+                  checked={bannerType === 'warning'}
+                  onChange={() => setBannerType('warning')}
+                  aria-label="Warning banner type"
+                />
                 <span className="banner-type-indicator warning" />
                 Warning
-              </div>
-              <div
+              </label>
+              <label
                 id="error-type-option"
                 className={`banner-type-option ${bannerType === 'error' ? 'selected' : ''}`}
-                onClick={() => setBannerType('error')}
               >
+                <input
+                  type="radio"
+                  name="bannerType"
+                  value="error"
+                  checked={bannerType === 'error'}
+                  onChange={() => setBannerType('error')}
+                  aria-label="Error banner type"
+                />
                 <span className="banner-type-indicator error" />
                 Error
-              </div>
+              </label>
             </div>
           </div>
 

--- a/frontend/src/styles/ReviewPage.css
+++ b/frontend/src/styles/ReviewPage.css
@@ -1001,6 +1001,14 @@ textarea.technology-input {
   transition: all 0.2s ease;
 }
 
+.banner-type-option input[type='radio'] {
+  margin: 0;
+  width: 0;
+  height: 0;
+  visibility: hidden;
+  position: absolute;
+}
+
 .banner-type-option:hover {
   background: hsl(var(--accent));
 }

--- a/testing/ui/tests/review.test.js
+++ b/testing/ui/tests/review.test.js
@@ -70,7 +70,7 @@ test('Check that directorate dropdown is present and has expected options', asyn
   await interceptAPICall({ page });
 
   // Check that the directorate selector is present
-  const directorateSelector = page.locator('select#directorate-select');
+  const directorateSelector = page.locator('select#directorate-select', { waitUntil: 'domcontentloaded' });
   await expect(directorateSelector).toBeVisible();
 
   // Check that all the directorates are present

--- a/testing/ui/tests/review.test.js
+++ b/testing/ui/tests/review.test.js
@@ -44,7 +44,6 @@ const interceptAPICall = async ({ page, mockedRadarData = radarData }) => {
   await interceptAPIJsonCall({ page });
   await interceptAPICSVCall({ page });
   await interceptAPIDirectoratesCall({ page });
-  await page.goto('http://localhost:3000/review/dashboard');
 
   // Clear all cookies
   await page.context().clearCookies();
@@ -61,8 +60,10 @@ const interceptAPICall = async ({ page, mockedRadarData = radarData }) => {
       sameSite: 'Lax',
     },
   ]);
-  await page.reload();
+
+  await page.goto('http://localhost:3000/review/dashboard', { waitUntil: 'domcontentloaded' });
 };
+
 
 test('Check that directorate dropdown is present and has expected options', async ({
   page,
@@ -70,7 +71,7 @@ test('Check that directorate dropdown is present and has expected options', asyn
   await interceptAPICall({ page });
 
   // Check that the directorate selector is present
-  const directorateSelector = page.locator('select#directorate-select', { waitUntil: 'domcontentloaded' });
+  const directorateSelector = page.locator('select#directorate-select');
   await expect(directorateSelector).toBeVisible();
 
   // Check that all the directorates are present


### PR DESCRIPTION
## Overview

<!-- Provide an overview of the changes in this pull request -->

Moved the loading of cookies above the loading of the page to remove redundant reload. Added waitUntil domcontentloaded into the api intercept to fix the test failure. The test was failing because the data was not loading in time, rather than due to a logic error.

## Related Issues

<!-- List any related issues or pull requests here -->
<!-- This can include issues from Jira but make sure *not* to link them -->
KEH-2364

## Testing

<!-- Describe how to test the changes in this pull request -->
Review code, run tests

## Checklist

<!-- Please check off the following items before submitting this pull request -->
<!-- If anything is not applicable, please explain why in the exemptions section -->

- [x] I have reviewed the changes in this pull request
- [x] I have tested the changes locally
- [ ] All CI checks have passed
- [x] I have added any necessary labels to this pull request
- [x] I have assigned myself to this pull request
- [x] I have assigned the appropriate reviewers to this pull request
