### PR TITLE
KEH-2364: Fixed test failure by adjusting data loading order

### DIFF
--- a/testing/ui/tests/review.test.js
+++ b/testing/ui/tests/review.test.js
@@ -61,7 +61,9 @@ const interceptAPICall = async ({ page, mockedRadarData = radarData }) => {
     },
   ]);
 
-  await page.goto('http://localhost:3000/review/dashboard', { waitUntil: 'load' });
+  await page.goto('http://localhost:3000/review/dashboard', {
+    waitUntil: 'load',
+  });
 };
 
 test('Check that directorate dropdown is present and has expected options', async ({

--- a/testing/ui/tests/review.test.js
+++ b/testing/ui/tests/review.test.js
@@ -61,9 +61,7 @@ const interceptAPICall = async ({ page, mockedRadarData = radarData }) => {
     },
   ]);
 
-  await page.goto('http://localhost:3000/review/dashboard', {
-    waitUntil: 'domcontentloaded',
-  });
+  await page.goto('http://localhost:3000/review/dashboard', { waitUntil: 'load' });
 };
 
 test('Check that directorate dropdown is present and has expected options', async ({
@@ -72,7 +70,7 @@ test('Check that directorate dropdown is present and has expected options', asyn
   await interceptAPICall({ page });
 
   // Check that the directorate selector is present
-  const directorateSelector = page.locator('select#directorate-select');
+  const directorateSelector = page.getByLabel('Select Directorate');
   await expect(directorateSelector).toBeVisible();
 
   // Check that all the directorates are present

--- a/testing/ui/tests/review.test.js
+++ b/testing/ui/tests/review.test.js
@@ -61,9 +61,10 @@ const interceptAPICall = async ({ page, mockedRadarData = radarData }) => {
     },
   ]);
 
-  await page.goto('http://localhost:3000/review/dashboard', { waitUntil: 'domcontentloaded' });
+  await page.goto('http://localhost:3000/review/dashboard', {
+    waitUntil: 'domcontentloaded',
+  });
 };
-
 
 test('Check that directorate dropdown is present and has expected options', async ({
   page,

--- a/testing/ui/tests/review.test.js
+++ b/testing/ui/tests/review.test.js
@@ -44,7 +44,6 @@ const interceptAPICall = async ({ page, mockedRadarData = radarData }) => {
   await interceptAPIJsonCall({ page });
   await interceptAPICSVCall({ page });
   await interceptAPIDirectoratesCall({ page });
-  await page.goto('http://localhost:3000/review/dashboard');
 
   // Clear all cookies
   await page.context().clearCookies();
@@ -61,8 +60,10 @@ const interceptAPICall = async ({ page, mockedRadarData = radarData }) => {
       sameSite: 'Lax',
     },
   ]);
-  await page.reload();
+
+  await page.goto('http://localhost:3000/review/dashboard', { waitUntil: 'domcontentloaded' });
 };
+
 
 test('Check that directorate dropdown is present and has expected options', async ({
   page,


### PR DESCRIPTION
## Overview

<!-- Provide an overview of the changes in this pull request -->

Moved the loading of cookies above the loading of the page to remove redundant reload. Added waitUntil domcontentloaded into the api intercept to fix the test failure. The test was failing because the data was not loading in time, rather than due to a logic error.

## Related Issues

<!-- List any related issues or pull requests here -->
<!-- This can include issues from Jira but make sure *not* to link them -->
KEH-2364

## Testing

<!-- Describe how to test the changes in this pull request -->
Review code, run tests

## Checklist

<!-- Please check off the following items before submitting this pull request -->
<!-- If anything is not applicable, please explain why in the exemptions section -->

- [x] I have reviewed the changes in this pull request
- [x] I have tested the changes locally
- [ ] All CI checks have passed
- [x] I have added any necessary labels to this pull request
- [x] I have assigned myself to this pull request
- [x] I have assigned the appropriate reviewers to this pull request
