### PR TITLE
fix: conflicting css between new and old dashboard

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,7 +22,7 @@
         "react-hot-toast": "^2.4.1",
         "react-icons": "^5.3.0",
         "react-router": "^7.18.0",
-        "react-router-dom": "^7.16.0",
+        "react-router-dom": "^7.18.0",
         "recharts": "^2.15.4",
         "string-similarity": "^4.0.4",
         "vite": "^8.0.16"
@@ -5498,12 +5498,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
-      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.0.tgz",
+      "integrity": "sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.16.0"
+        "react-router": "7.18.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -5511,28 +5511,6 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
-      }
-    },
-    "node_modules/react-router-dom/node_modules/react-router": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
       }
     },
     "node_modules/react-smooth": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "react-dom": "^18.3.1",
         "react-hot-toast": "^2.4.1",
         "react-icons": "^5.3.0",
+        "react-router": "^7.18.0",
         "react-router-dom": "^7.16.0",
         "recharts": "^2.15.4",
         "string-similarity": "^4.0.4",
@@ -5475,9 +5476,9 @@
       "license": "MIT"
     },
     "node_modules/react-router": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.0.tgz",
+      "integrity": "sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -5510,6 +5511,28 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router-dom/node_modules/react-router": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
+      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-smooth": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "react-dom": "^18.3.1",
     "react-hot-toast": "^2.4.1",
     "react-icons": "^5.3.0",
+    "react-router": "^7.18.0",
     "react-router-dom": "^7.16.0",
     "recharts": "^2.15.4",
     "string-similarity": "^4.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
     "react-hot-toast": "^2.4.1",
     "react-icons": "^5.3.0",
     "react-router": "^7.18.0",
-    "react-router-dom": "^7.16.0",
+    "react-router-dom": "^7.18.0",
     "recharts": "^2.15.4",
     "string-similarity": "^4.0.4",
     "vite": "^8.0.16"

--- a/frontend/src/components/Copilot/Breakdowns/AcceptanceGraph.js
+++ b/frontend/src/components/Copilot/Breakdowns/AcceptanceGraph.js
@@ -14,7 +14,7 @@ import { formatNumberWithCommas } from '../../../utilities/getCommaSeparated';
 
 const AcceptanceGraph = ({ data }) => {
   return (
-    <div className="copilot-graph-container">
+    <div className="copilot-graph-container--old">
       <ResponsiveContainer>
         <ComposedChart
           width={400}

--- a/frontend/src/components/Copilot/Breakdowns/CodeImpactByLanguage.js
+++ b/frontend/src/components/Copilot/Breakdowns/CodeImpactByLanguage.js
@@ -40,12 +40,16 @@ function CodeImpactByLanguage({ data }) {
             separator=": "
             formatter={value => `${value}%`}
             contentStyle={{
-              backgroundColor: isDark ? 'hsl(240, 10%, 8%)' : 'hsl(0, 0%, 100%)',
+              backgroundColor: isDark
+                ? 'hsl(240, 10%, 8%)'
+                : 'hsl(0, 0%, 100%)',
               border: `1px solid ${isDark ? 'hsl(240, 3.7%, 25.9%)' : 'hsl(240, 5.9%, 90%)'}`,
               borderRadius: '0.5rem',
               color: isDark ? 'hsl(0, 0%, 98%)' : 'hsl(240, 10%, 3.9%)',
             }}
-            itemStyle={{ color: isDark ? 'hsl(0, 0%, 98%)' : 'hsl(240, 10%, 3.9%)' }}
+            itemStyle={{
+              color: isDark ? 'hsl(0, 0%, 98%)' : 'hsl(240, 10%, 3.9%)',
+            }}
           />
           <Legend iconType="circle" iconSize={10} />
         </PieChart>

--- a/frontend/src/components/Copilot/Breakdowns/CodeImpactByLanguage.js
+++ b/frontend/src/components/Copilot/Breakdowns/CodeImpactByLanguage.js
@@ -12,7 +12,8 @@ import { getChartPalette } from '../../../utilities/copilotChartColours';
 
 function CodeImpactByLanguage({ data }) {
   const { theme } = useTheme();
-  const colours = getChartPalette(data.length, theme === 'dark');
+  const isDark = theme === 'dark';
+  const colours = getChartPalette(data.length, isDark);
 
   return (
     <div className="usage-pie-chart-card">
@@ -35,7 +36,17 @@ function CodeImpactByLanguage({ data }) {
               <Cell key={`lang-${index}`} fill={colours[index]} />
             ))}
           </Pie>
-          <Tooltip formatter={value => `${value}%`} />
+          <Tooltip
+            separator=": "
+            formatter={value => `${value}%`}
+            contentStyle={{
+              backgroundColor: isDark ? 'hsl(240, 10%, 8%)' : 'hsl(0, 0%, 100%)',
+              border: `1px solid ${isDark ? 'hsl(240, 3.7%, 25.9%)' : 'hsl(240, 5.9%, 90%)'}`,
+              borderRadius: '0.5rem',
+              color: isDark ? 'hsl(0, 0%, 98%)' : 'hsl(240, 10%, 3.9%)',
+            }}
+            itemStyle={{ color: isDark ? 'hsl(0, 0%, 98%)' : 'hsl(240, 10%, 3.9%)' }}
+          />
           <Legend iconType="circle" iconSize={10} />
         </PieChart>
       </ResponsiveContainer>

--- a/frontend/src/components/Copilot/Breakdowns/EngagedUsersGraph.js
+++ b/frontend/src/components/Copilot/Breakdowns/EngagedUsersGraph.js
@@ -13,7 +13,7 @@ import { formatNumberWithCommas } from '../../../utilities/getCommaSeparated';
 
 const EngagedUsersGraph = ({ data }) => {
   return (
-    <div className="copilot-graph-container">
+    <div className="copilot-graph-container--old">
       <ResponsiveContainer>
         <ComposedChart
           width={400}

--- a/frontend/src/components/Copilot/Breakdowns/ModelIdeUsage.js
+++ b/frontend/src/components/Copilot/Breakdowns/ModelIdeUsage.js
@@ -54,7 +54,17 @@ function ModelIdeUsage({ modelData, ideData }) {
                 <Cell key={`model-${index}`} fill={modelColours[index]} />
               ))}
             </Pie>
-            <RechartsTooltip formatter={value => `${value}%`} />
+            <RechartsTooltip
+              separator=": "
+              formatter={value => `${value}%`}
+              contentStyle={{
+                backgroundColor: isDark ? 'hsl(240, 10%, 8%)' : 'hsl(0, 0%, 100%)',
+                border: `1px solid ${isDark ? 'hsl(240, 3.7%, 25.9%)' : 'hsl(240, 5.9%, 90%)'}`,
+                borderRadius: '0.5rem',
+                color: isDark ? 'hsl(0, 0%, 98%)' : 'hsl(240, 10%, 3.9%)',
+              }}
+              itemStyle={{ color: isDark ? 'hsl(0, 0%, 98%)' : 'hsl(240, 10%, 3.9%)' }}
+            />
             <Legend iconType="circle" iconSize={10} />
           </PieChart>
         </ResponsiveContainer>
@@ -93,7 +103,17 @@ function ModelIdeUsage({ modelData, ideData }) {
                 <Cell key={`ide-${index}`} fill={ideColours[index]} />
               ))}
             </Pie>
-            <RechartsTooltip formatter={value => `${value}%`} />
+            <RechartsTooltip
+              separator=": "
+              formatter={value => `${value}%`}
+              contentStyle={{
+                backgroundColor: isDark ? 'hsl(240, 10%, 8%)' : 'hsl(0, 0%, 100%)',
+                border: `1px solid ${isDark ? 'hsl(240, 3.7%, 25.9%)' : 'hsl(240, 5.9%, 90%)'}`,
+                borderRadius: '0.5rem',
+                color: isDark ? 'hsl(0, 0%, 98%)' : 'hsl(240, 10%, 3.9%)',
+              }}
+              itemStyle={{ color: isDark ? 'hsl(0, 0%, 98%)' : 'hsl(240, 10%, 3.9%)' }}
+            />
             <Legend iconType="circle" iconSize={10} />
           </PieChart>
         </ResponsiveContainer>

--- a/frontend/src/components/Copilot/Breakdowns/ModelIdeUsage.js
+++ b/frontend/src/components/Copilot/Breakdowns/ModelIdeUsage.js
@@ -58,12 +58,16 @@ function ModelIdeUsage({ modelData, ideData }) {
               separator=": "
               formatter={value => `${value}%`}
               contentStyle={{
-                backgroundColor: isDark ? 'hsl(240, 10%, 8%)' : 'hsl(0, 0%, 100%)',
+                backgroundColor: isDark
+                  ? 'hsl(240, 10%, 8%)'
+                  : 'hsl(0, 0%, 100%)',
                 border: `1px solid ${isDark ? 'hsl(240, 3.7%, 25.9%)' : 'hsl(240, 5.9%, 90%)'}`,
                 borderRadius: '0.5rem',
                 color: isDark ? 'hsl(0, 0%, 98%)' : 'hsl(240, 10%, 3.9%)',
               }}
-              itemStyle={{ color: isDark ? 'hsl(0, 0%, 98%)' : 'hsl(240, 10%, 3.9%)' }}
+              itemStyle={{
+                color: isDark ? 'hsl(0, 0%, 98%)' : 'hsl(240, 10%, 3.9%)',
+              }}
             />
             <Legend iconType="circle" iconSize={10} />
           </PieChart>
@@ -107,12 +111,16 @@ function ModelIdeUsage({ modelData, ideData }) {
               separator=": "
               formatter={value => `${value}%`}
               contentStyle={{
-                backgroundColor: isDark ? 'hsl(240, 10%, 8%)' : 'hsl(0, 0%, 100%)',
+                backgroundColor: isDark
+                  ? 'hsl(240, 10%, 8%)'
+                  : 'hsl(0, 0%, 100%)',
                 border: `1px solid ${isDark ? 'hsl(240, 3.7%, 25.9%)' : 'hsl(240, 5.9%, 90%)'}`,
                 borderRadius: '0.5rem',
                 color: isDark ? 'hsl(0, 0%, 98%)' : 'hsl(240, 10%, 3.9%)',
               }}
-              itemStyle={{ color: isDark ? 'hsl(0, 0%, 98%)' : 'hsl(240, 10%, 3.9%)' }}
+              itemStyle={{
+                color: isDark ? 'hsl(0, 0%, 98%)' : 'hsl(240, 10%, 3.9%)',
+              }}
             />
             <Legend iconType="circle" iconSize={10} />
           </PieChart>

--- a/frontend/src/components/Copilot/Dashboards/LegacyData.js
+++ b/frontend/src/components/Copilot/Dashboards/LegacyData.js
@@ -68,7 +68,7 @@ function LegacyDataVisualisation({ data, isLoading }) {
           </div>
         </div>
 
-        <div className="copilot-graph-container copilot-graph-container--stacked">
+        <div className="copilot-graph-container--old copilot-graph-container--stacked">
           <div
             className="skeleton"
             style={{ height: 300, borderRadius: 8, marginBottom: 16 }}
@@ -107,7 +107,7 @@ function LegacyDataVisualisation({ data, isLoading }) {
             <SkeletonStatCard />
           </div>
 
-          <div className="copilot-graph-container copilot-graph-container--stacked">
+          <div className="copilot-graph-container--old copilot-graph-container--stacked">
             <div
               className="skeleton"
               style={{ height: 300, borderRadius: 8, marginBottom: 16 }}
@@ -281,7 +281,7 @@ function LegacyDataVisualisation({ data, isLoading }) {
           </div>
         </div>
 
-        <div className="copilot-graph-container copilot-graph-container--stacked">
+        <div className="copilot-graph-container--old copilot-graph-container--stacked">
           <ResponsiveContainer width="100%" height={300}>
             <ComposedChart
               width={400}
@@ -487,7 +487,7 @@ function LegacyDataVisualisation({ data, isLoading }) {
           </div>
         </div>
 
-        <div className="copilot-graph-container copilot-graph-container--stacked">
+        <div className="copilot-graph-container--old copilot-graph-container--stacked">
           <ResponsiveContainer width="100%" height={300}>
             <ComposedChart
               width={400}

--- a/frontend/src/styles/Copilot/GeneralUsagePage.css
+++ b/frontend/src/styles/Copilot/GeneralUsagePage.css
@@ -7,13 +7,26 @@
 }
 
 .usage-card {
-  background: hsl(var(--card));
-  border: 1px solid hsl(var(--border));
+  position: relative;
+  background: hsl(var(--background));
+  box-shadow: 0 0 0 1px hsl(var(--foreground) / 4%);
   border-radius: var(--radius);
   padding: 20px;
   display: flex;
   flex-direction: column;
   gap: 16px;
+  z-index: 1;
+}
+
+.usage-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow:
+    0 10px 15px -5px hsl(var(--foreground) / 6%),
+    0 4px 6px -2px hsl(var(--foreground) / 4%);
+  z-index: -1;
 }
 
 .usage-card-title {
@@ -83,8 +96,6 @@
 
 .usage-pie-chart-card {
   background: hsl(var(--card));
-  border: 1px solid hsl(var(--border));
-  border-radius: var(--radius);
   padding: 20px;
   flex: 1;
 }

--- a/frontend/src/styles/Copilot/GeneralUsagePage.css
+++ b/frontend/src/styles/Copilot/GeneralUsagePage.css
@@ -19,7 +19,7 @@
 }
 
 .usage-card::after {
-  content: "";
+  content: '';
   position: absolute;
   inset: 0;
   border-radius: inherit;

--- a/frontend/src/styles/Copilot/ReusableStyles.css
+++ b/frontend/src/styles/Copilot/ReusableStyles.css
@@ -61,8 +61,6 @@ Copilot Dashboard */
 
 .copilot-graph-container {
   background: hsl(var(--card));
-  border: 1px solid hsl(var(--border));
-  border-radius: var(--radius);
 }
 
 .copilot-tooltip-paragraph {

--- a/frontend/src/styles/Copilot/ReusableStyles.css
+++ b/frontend/src/styles/Copilot/ReusableStyles.css
@@ -49,15 +49,20 @@ Copilot Dashboard */
   padding-bottom: 20px;
 }
 
-.copilot-graph-container {
-  background: hsl(var(--card));
-  border: 1px solid hsl(var(--border));
-  border-radius: var(--radius);
+.copilot-graph-container--old {
+  width: calc(100% - 16px);
+  height: calc(50vh - 16px);
 }
 
 .copilot-graph-container--stacked {
   height: auto;
   margin-bottom: 24px;
+}
+
+.copilot-graph-container {
+  background: hsl(var(--card));
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
 }
 
 .copilot-tooltip-paragraph {

--- a/frontend/src/styles/CopilotPage.css
+++ b/frontend/src/styles/CopilotPage.css
@@ -308,7 +308,7 @@ html:not(.dark)
   color: hsl(var(--primary));
 }
 
-.copilot-graph-container {
+.copilot-graph-container--old {
   width: calc(100% - 16px);
   height: calc(50vh - 16px);
 }

--- a/testing/ui/tests/copilot.legacy.test.js
+++ b/testing/ui/tests/copilot.legacy.test.js
@@ -7,6 +7,10 @@ test('Legacy Usage page routes correctly', async ({ page }) => {
 });
 
 test('Legacy Usage page shows skeleton loading state', async ({ page }) => {
+  await page.route('**/copilot/api/org/legacy*', async route => {
+    await new Promise(resolve => setTimeout(resolve, 2000));
+    await route.continue();
+  });
   await page.goto('http://localhost:3000/copilot/legacy');
   await expect(page.locator('.stat-card.skeleton').first()).toBeVisible();
 });
@@ -70,7 +74,7 @@ test('Legacy Usage page displays the January 2025 - March 2026 dataset correctly
   ).toBeVisible();
 
   // 2 graph containers: 1 AcceptanceGraph + 1 stacked (chat + user metrics)
-  await expect(section.locator('.copilot-graph-container')).toHaveCount(2);
+  await expect(section.locator('.copilot-graph-container--old')).toHaveCount(2);
 });
 
 test('Legacy Usage page displays the May 2024 - January 2025 dataset correctly', async ({
@@ -126,7 +130,7 @@ test('Legacy Usage page displays the May 2024 - January 2025 dataset correctly',
   ).toBeVisible();
 
   // 2 graph containers: 1 AcceptanceGraph + 1 stacked (chat + user metrics)
-  await expect(section.locator('.copilot-graph-container')).toHaveCount(2);
+  await expect(section.locator('.copilot-graph-container--old')).toHaveCount(2);
 });
 
 test('Legacy Usage page back button navigates to landing page', async ({


### PR DESCRIPTION
## Overview

This PR fixes a conflicting CSS issue between the new and old dashboard - causing the container for the graphs on the new dashboard to not expand properly to fit the graph.

## Related Issues

KEH-2319

## Testing

`make dev` and check that the layouts when switching between the new and old dashboards stays consistent

## Checklist

<!-- Please check off the following items before submitting this pull request -->
<!-- If anything is not applicable, please explain why in the exemptions section -->

- [x] I have reviewed the changes in this pull request
- [x] I have tested the changes locally
- [ ] I have updated/created any relevant documentation
- [ ] I have updated/created any relevant tests
- [x] All CI checks have passed
- [ ] I have used a development Concourse pipeline to test the changes within a development environment
- [x] I have added any necessary labels to this pull request
- [x] I have assigned myself to this pull request
- [x] I have assigned the appropriate reviewers to this pull request

### Exemptions

Concourse dev pipeline not needed for these changes. Tests and Documentation already implemented as part of KEH-2319.

## Additional Notes

N/A